### PR TITLE
Fix typing for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-mock flake8 mypy
+      - name: Lint with flake8
+        run: |
+          flake8 --max-line-length=100 --exclude=__pycache__,logs .
+      - name: Type check with mypy
+        run: |
+          mypy --ignore-missing-imports .
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=./ --cov-report=xml
+      - name: Enforce 80% coverage
+        run: |
+          python - <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+root = ET.parse('coverage.xml').getroot()
+total = root.find('coverage').attrib['line-rate']
+coverage = float(total) * 100
+print(f"coverage: {coverage:.2f}%")
+if coverage < 80:
+    sys.exit(1)
+PY
+      - name: Upload coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage.xml

--- a/audit.py
+++ b/audit.py
@@ -1,0 +1,48 @@
+import json
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+
+LOG_PATH = Path('/home/pi/sz/logs/override_log.jsonl')
+
+
+def _get_last_hash() -> str:
+    if not LOG_PATH.exists():
+        return ""
+    try:
+        with open(LOG_PATH, 'rb') as f:
+            f.seek(0, 2)
+            if f.tell() == 0:
+                return ""
+            pos = f.tell() - 1
+            while pos > 0:
+                f.seek(pos)
+                if f.read(1) == b'\n':
+                    break
+                pos -= 1
+            if pos <= 0:
+                f.seek(0)
+            line = f.readline().decode().strip()
+        if line:
+            return json.loads(line).get('hash', '')
+    except Exception:
+        return ""
+    return ""
+
+
+def log_override(mode: str, duration_minutes: int, source: str, initiated_by: str) -> None:
+    """Append an override event to the audit log with hash chaining."""
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    prev = _get_last_hash()
+    event = {
+        'timestamp': datetime.now(timezone.utc).isoformat(),
+        'mode': mode,
+        'duration_minutes': duration_minutes,
+        'source': source,
+        'initiated_by': initiated_by,
+    }
+    plain = json.dumps(event, sort_keys=True)
+    event['hash'] = hashlib.sha256((plain + prev).encode()).hexdigest()
+    with open(LOG_PATH, 'a') as f:
+        f.write(json.dumps(event) + '\n')
+

--- a/audit_verifier.py
+++ b/audit_verifier.py
@@ -1,0 +1,40 @@
+import json
+import hashlib
+import sys
+from pathlib import Path
+
+DEFAULT_PATH = Path('/home/pi/sz/logs/override_log.jsonl')
+
+
+def verify(path: Path) -> bool:
+    prev = ''
+    try:
+        with open(path) as f:
+            for idx, line in enumerate(f, 1):
+                obj = json.loads(line)
+                core = {
+                    'timestamp': obj['timestamp'],
+                    'mode': obj['mode'],
+                    'duration_minutes': obj['duration_minutes'],
+                    'source': obj['source'],
+                    'initiated_by': obj['initiated_by'],
+                }
+                calc = hashlib.sha256((json.dumps(core, sort_keys=True) + prev).encode()).hexdigest()
+                if calc != obj.get('hash'):
+                    print(f'Hash mismatch at line {idx}')
+                    return False
+                prev = obj['hash']
+    except FileNotFoundError:
+        print('Audit file not found')
+        return False
+    print('Valid audit trail \u2705')
+    return True
+
+
+def main() -> None:
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_PATH
+    verify(path)
+
+
+if __name__ == '__main__':
+    main()

--- a/button_override.py
+++ b/button_override.py
@@ -1,0 +1,41 @@
+"""Physical button override handler."""
+from logger import get_logger
+import time
+try:
+    import RPi.GPIO as GPIO
+    from threading import Thread
+except Exception:  # pragma: no cover - hardware not present
+    GPIO = None
+    Thread = object
+
+
+class OverrideButton(Thread):
+    """Monitor a GPIO button for manual override."""
+
+    def __init__(self, pin, override_mgr):
+        super().__init__(daemon=True)
+        self.pin = pin
+        self.override_mgr = override_mgr
+        self.logger = get_logger(__name__)
+        if GPIO:
+            GPIO.setmode(GPIO.BCM)
+            GPIO.setup(self.pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+
+    def run(self):
+        if not GPIO:
+            return
+        self.logger.info("Listening for override button presses")
+        while True:
+            if GPIO.input(self.pin) == GPIO.LOW:
+                current = self.override_mgr.state.get('override_mode')
+                new_mode = 'OFF' if current and current != 'OFF' else 'FAN_ONLY'
+                self.override_mgr.apply_override(
+                    new_mode,
+                    30,
+                    'button',
+                    'button'
+                )
+                self.logger.info("Override mode set to %s", new_mode)
+                while GPIO.input(self.pin) == GPIO.LOW:
+                    pass
+            time.sleep(0.1)

--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,17 @@
+{
+    "pins": {
+        "dht": 17,
+        "motion": 27,
+        "cooling": 23,
+        "heating": 22,
+        "fan": 24,
+        "button": 6
+    },
+    "thresholds": {
+        "cool": 75,
+        "heat": 68
+    },
+    "loop_interval": 5,
+    "motion_timeout": 300,
+    "api_key": "mysecret"
+}

--- a/control.py
+++ b/control.py
@@ -1,0 +1,42 @@
+"""HVAC control logic built on HardwareInterface."""
+from logger import get_logger
+from typing import Optional
+
+from hardware import HardwareInterface
+
+VALID_MODES = {"COOL_ON", "HEAT_ON", "FAN_ONLY", "OFF"}
+
+
+class HVACController:
+    """Manage HVAC mode transitions."""
+
+    def __init__(self, config, hardware: Optional[HardwareInterface] = None):
+        self.logger = get_logger(__name__)
+        self.hardware = hardware or HardwareInterface(config)
+        self.last_mode = None
+
+    def set_mode(self, mode: str) -> None:
+        """Set the HVAC to the requested mode."""
+        if mode not in VALID_MODES:
+            raise ValueError(f"Invalid mode: {mode}")
+        if mode == self.last_mode:
+            return
+        self.logger.info("Changing mode from %s to %s", self.last_mode, mode)
+        if mode == "OFF":
+            self.hardware.deactivate_all()
+        elif mode == "COOL_ON":
+            self.hardware.deactivate_all()
+            self.hardware.activate("cooling")
+            self.hardware.activate("fan")
+        elif mode == "HEAT_ON":
+            self.hardware.deactivate_all()
+            self.hardware.activate("heating")
+            self.hardware.activate("fan")
+        elif mode == "FAN_ONLY":
+            self.hardware.deactivate_all()
+            self.hardware.activate("fan")
+        self.last_mode = mode
+
+    def cleanup(self) -> None:
+        """Cleanup GPIO resources."""
+        self.hardware.cleanup()

--- a/deploy_to_pi.sh
+++ b/deploy_to_pi.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Automated deployment script for SentientZone
+
+PI_HOST="raspberrypi.local"
+PI_USER="pi"
+PI_PASS="raspberry"
+REPO_URL="<REPLACE_WITH_YOUR_REPO>"
+
+if ! command -v sshpass >/dev/null; then
+  echo "sshpass is required. Please install it first." >&2
+  exit 1
+fi
+
+sshpass -p "$PI_PASS" ssh -o StrictHostKeyChecking=no $PI_USER@$PI_HOST <<'EOF_REMOTE'
+set -e
+
+sudo apt-get update
+sudo apt-get install -y git python3 python3-pip python3-flask
+sudo pip3 install adafruit-circuitpython-dht RPi.GPIO
+
+if [ ! -d /opt/sentientzone ]; then
+    sudo git clone "$REPO_URL" /opt/sentientzone
+fi
+
+cd /opt/sentientzone
+sudo cp sz_ui.service /etc/systemd/system/sz_ui.service
+sudo systemctl daemon-reload
+sudo systemctl enable sz_ui.service
+sudo systemctl restart sz_ui.service
+EOF_REMOTE
+
+echo "Deployment complete."

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,56 @@
+# API Reference
+
+All POST requests require an `X-API-Key` header that matches the `api_key` value
+in `config/config.json`. The server listens on `127.0.0.1:8080`.
+
+## GET /state
+
+Returns the full state stored by `StateManager`.
+
+```
+{
+  "override_mode": "OFF",
+  "override_until": null,
+  "last_temp_f": 72.4,
+  "last_motion_ts": 1685553912.0,
+  "current_mode": "FAN_ONLY"
+}
+```
+
+## POST /override
+
+Apply a temporary override.
+
+```
+POST /override
+Headers: X-API-Key: <key>
+{
+  "mode": "HEAT_ON",
+  "duration_minutes": 30,
+  "source": "api"
+}
+```
+
+Responses:
+- `200` with new override state
+- `400` for invalid input
+- `401` if the API key is missing or wrong
+
+## GET /logs
+
+Returns the current log file as plain text.
+
+## GET /healthz
+
+Reports service status. Returns `200` with JSON if healthy, otherwise `503`.
+
+```
+{
+  "status": "ok",
+  "uptime_sec": 1234,
+  "mode": "FAN_ONLY",
+  "last_temp_f": 72.5,
+  "override_active": false,
+  "errors": 0
+}
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,46 @@
+# Configuration
+
+All runtime settings are stored in `config/config.json`. The file is loaded by
+`StateManager` at startup.
+
+## Schema
+
+- `pins.dht` – GPIO for the DHT22 sensor
+- `pins.motion` – GPIO for the PIR motion sensor
+- `pins.cooling` – GPIO controlling the cooling relay
+- `pins.heating` – GPIO controlling the heating relay
+- `pins.fan` – GPIO controlling the fan relay
+- `pins.button` – GPIO for the optional override button
+- `thresholds.cool` – temperature in °F above which cooling activates
+- `thresholds.heat` – temperature in °F below which heating activates
+- `loop_interval` – seconds between control loop iterations
+- `motion_timeout` – seconds after last motion allowed for cooling
+- `api_key` – key required for POST requests
+
+## Example
+
+```json
+{
+  "pins": {
+    "dht": 17,
+    "motion": 27,
+    "cooling": 23,
+    "heating": 22,
+    "fan": 24,
+    "button": 6
+  },
+  "thresholds": {
+    "cool": 75,
+    "heat": 68
+  },
+  "loop_interval": 5,
+  "motion_timeout": 300,
+  "api_key": "mysecret"
+}
+```
+
+### Guidelines
+
+- Modify the file only when the service is stopped to avoid race conditions.
+- Keep a backup of the original configuration.
+- Ensure the API key is kept secret if the network is exposed.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,24 @@
+# System Overview
+
+SentientZone runs entirely on a Raspberry Pi and does not require an internet connection. It
+collects temperature and motion data and decides which HVAC mode to run.
+
+## Architecture
+
+```
+[DHT22 + PIR] --> [SensorManager] --> [StateManager]
+                                  \-> [MetricsManager]
+[OverrideButton / API] --> [OverrideManager] --> [HVACController]
+                                           \-> [StateManager]
+                                 [Flask API]
+                                    |
+                                  Users
+```
+
+1. **SensorManager** reads temperature and motion every loop.
+2. **OverrideManager** can force a mode for a set duration.
+3. **HVACController** drives relays through the hardware interface.
+4. **MetricsManager** records recent readings and errors.
+5. **SentientZoneServer** exposes HTTP endpoints for monitoring and overrides.
+
+The main loop in `main.py` ties these pieces together and handles shutdown signals.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,37 @@
+# Troubleshooting
+
+This guide covers common issues seen when deploying SentientZone.
+
+## Sensor Read Failures
+
+- Ensure the DHT22 and PIR sensors are wired correctly.
+- Check that the pins in `config/config.json` match your wiring.
+- Look for errors in `/home/pi/sz/logs/sentientzone.log`.
+
+## Permission Denied on GPIO
+
+- The service must run with permissions to access `/dev/gpiomem`.
+- Running via the provided `sz_ui.service` unit grants the required access.
+
+## Service Will Not Start
+
+- Inspect the service logs with `sudo journalctl -u sz_ui.service`.
+- Verify Python dependencies are installed in `/home/pi/sz/venv`.
+- Confirm that `state/` and `logs/` directories exist and are writable.
+
+## Logs Missing or Not Rotating
+
+- Check file permissions on `/home/pi/sz/logs`.
+- The logger rotates files daily and keeps 7 backups.
+- If the directory is on a read-only filesystem, logging will fail.
+
+## Resetting State Safely
+
+If the state file becomes corrupted you can reset it:
+
+```bash
+sudo systemctl stop sz_ui.service
+rm -f /home/pi/sz/state/state.json
+cp /home/pi/sz/state/state_backup.json /home/pi/sz/state/state.json
+sudo systemctl start sz_ui.service
+```

--- a/hardware.py
+++ b/hardware.py
@@ -1,0 +1,64 @@
+"""GPIO hardware interface for SentientZone."""
+import json
+from logger import get_logger
+from pathlib import Path
+
+try:
+    import RPi.GPIO as GPIO
+except Exception:  # pragma: no cover - hardware not present
+    GPIO = None
+
+
+class HardwareInterface:
+    """Abstraction layer for HVAC relay control."""
+
+    def __init__(self, config):
+        self.logger = get_logger(__name__)
+        if isinstance(config, (str, Path)):
+            with open(config, 'r') as f:
+                config = json.load(f)
+        self.pins = {
+            'cooling': config['pins']['cooling'],
+            'heating': config['pins']['heating'],
+            'fan': config['pins']['fan'],
+        }
+        if GPIO:
+            GPIO.setwarnings(False)
+            GPIO.setmode(GPIO.BCM)
+            try:
+                for pin in self.pins.values():
+                    GPIO.setup(pin, GPIO.OUT, initial=GPIO.LOW)
+            except Exception as exc:  # pragma: no cover - hardware not present
+                self.logger.exception("Failed GPIO setup: %s", exc)
+
+    def activate(self, pin_name: str) -> None:
+        """Activate a relay by pin name."""
+        pin = self.pins.get(pin_name)
+        if pin is None:
+            self.logger.error("Unknown pin name: %s", pin_name)
+            return
+        self.logger.info("Activating %s (GPIO %s)", pin_name, pin)
+        if GPIO:
+            try:
+                GPIO.output(pin, GPIO.HIGH)
+            except Exception as exc:  # pragma: no cover - hardware not present
+                self.logger.exception("Failed to activate %s: %s", pin_name, exc)
+
+    def deactivate_all(self) -> None:
+        """Turn off all relays."""
+        self.logger.info("Deactivating all relays")
+        if GPIO:
+            try:
+                for pin in self.pins.values():
+                    GPIO.output(pin, GPIO.LOW)
+            except Exception as exc:  # pragma: no cover - hardware not present
+                self.logger.exception("Failed to deactivate relays: %s", exc)
+
+    def cleanup(self) -> None:
+        """Clean up GPIO state."""
+        self.logger.info("Cleaning up GPIO")
+        if GPIO:
+            try:
+                GPIO.cleanup(list(self.pins.values()))
+            except Exception as exc:  # pragma: no cover - hardware not present
+                self.logger.exception("GPIO cleanup failed: %s", exc)

--- a/log_verifier.py
+++ b/log_verifier.py
@@ -1,0 +1,37 @@
+import hashlib
+import sys
+from pathlib import Path
+
+DEFAULT_LOG = Path('/home/pi/sz/logs/sentientzone.log')
+
+
+def verify(path: Path) -> bool:
+    prev = ''
+    try:
+        with open(path) as f:
+            for idx, line in enumerate(f, 1):
+                line = line.rstrip('\n')
+                try:
+                    content, hash_part = line.rsplit('| HASH:', 1)
+                except ValueError:
+                    print(f'Missing hash on line {idx}')
+                    return False
+                calc = hashlib.sha256((prev + content.strip()).encode()).hexdigest()
+                if calc != hash_part.strip():
+                    print(f'Hash mismatch at line {idx}')
+                    return False
+                prev = calc
+    except FileNotFoundError:
+        print('Log file not found')
+        return False
+    print('Valid log chain \u2705')
+    return True
+
+
+def main() -> None:
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_LOG
+    verify(path)
+
+
+if __name__ == '__main__':
+    main()

--- a/logger.py
+++ b/logger.py
@@ -1,197 +1,61 @@
-# /sz/src/logger.py
+import logging
+import hashlib
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
 
-"""
-Module: logger.py
-Purpose: Log sensor readings and decisions to CSV for audit and analysis.
-Consumes:
-- sensor_data (dict)
-- hvac_decision (dict)
-- StateManager for log file paths.
-Produces:
-- Configurable data.csv and decisions.csv files.
-- Logs structured rows with timestamp, temp, humid, motion, state, mode, cause.
-"""
-
-import csv
-import os
-import pathlib # For handling file paths as Path objects
-from datetime import datetime
-import logging # For logging internal module events/errors
-
-# REMOVE THIS LINE: from config_loader import CONFIG
-# ADD THIS IMPORT:
-from state_manager import StateManager
-
-# Setup module-specific logger for internal errors/info about logging operations
-logger_module_logger = logging.getLogger('LoggerModule')
-
-# Define headers for CSV files
-DATA_LOG_HEADERS = ["timestamp", "temperature", "humidity", "motion", "status"]
-DECISION_LOG_HEADERS = ["timestamp", "temperature", "humidity", "motion", "hvac_state", "mode", "cause"]
+LOG_PATH = Path('/home/pi/sz/logs/sentientzone.log')
+CHAIN_PATH = LOG_PATH.parent / 'log_chain.txt'
+_FORMAT = logging.Formatter('[%(asctime)s] %(levelname)s %(name)s - %(message)s')
+_configured = False
 
 
-def log_sensor_data(sensor_data: dict, state_manager: StateManager):
-    """
-    Append temperature, humidity, motion, and status to the sensor data CSV.
+class HashChainingHandler(TimedRotatingFileHandler):
+    """TimedRotatingFileHandler that appends a hash chain to each entry."""
 
-    Args:
-        sensor_data (dict): Dictionary containing sensor readings.
-        state_manager (StateManager): The application's state manager instance.
-    """
-    # Get the log directory and filename from StateManager
-    log_dir_str = state_manager.get_value('log_directory', '/var/log/sentientzone')
-    data_log_filename = state_manager.get_value('sensor_log_file', 'data.csv')
-    
-    # Construct the full path using pathlib for robust path handling
-    data_log_path = pathlib.Path(log_dir_str) / data_log_filename
+    def __init__(self, filename: str, chain_file: Path, **kwargs) -> None:
+        super().__init__(filename, **kwargs)
+        self.prev_hash = ''
+        self.chain_file = chain_file
 
-    row = [
-        _timestamp(),
-        sensor_data.get("temperature"), # Use .get() to safely access keys
-        sensor_data.get("humidity"),
-        int(sensor_data.get("motion", False)), # Default to False if missing, convert to int
-        sensor_data.get("status")
-    ]
-    _write_row(data_log_path, DATA_LOG_HEADERS, row)
-    logger_module_logger.debug(f"Logged sensor data: {row}")
+    def emit(self, record: logging.LogRecord) -> None:  # type: ignore[override]
+        try:
+            if self.shouldRollover(record):
+                self.doRollover()
+            if self.stream is None:
+                self.stream = self._open()
+            line = self.format(record)
+            digest = hashlib.sha256((self.prev_hash + line).encode()).hexdigest()
+            self.prev_hash = digest
+            self.stream.write(f"{line} | HASH: {digest}{self.terminator}")
+            self.flush()
+        except Exception:
+            self.handleError(record)
 
-
-def log_decision(sensor_data: dict, decision: dict, state_manager: StateManager):
-    """
-    Append HVAC decision result to the decisions CSV including cause and mode.
-
-    Args:
-        sensor_data (dict): Dictionary containing sensor readings at time of decision.
-        decision (dict): Dictionary containing the HVAC decision.
-        state_manager (StateManager): The application's state manager instance.
-    """
-    # Get the log directory and filename from StateManager
-    log_dir_str = state_manager.get_value('log_directory', '/var/log/sentientzone')
-    decision_log_filename = state_manager.get_value('hvac_log_file', 'decisions.csv')
-    
-    # Construct the full path using pathlib
-    decision_log_path = pathlib.Path(log_dir_str) / decision_log_filename
-
-    row = [
-        _timestamp(),
-        sensor_data.get("temperature"),
-        sensor_data.get("humidity"),
-        int(sensor_data.get("motion", False)),
-        decision.get("hvac_state"),
-        decision.get("mode"),
-        decision.get("cause")
-    ]
-    _write_row(decision_log_path, DECISION_LOG_HEADERS, row)
-    logger_module_logger.debug(f"Logged HVAC decision: {row}")
+    def close(self) -> None:  # type: ignore[override]
+        super().close()
+        try:
+            self.chain_file.parent.mkdir(parents=True, exist_ok=True)
+            with open(self.chain_file, 'a') as f:
+                f.write(self.prev_hash + '\n')
+        except Exception:
+            pass
 
 
-def _write_row(path: pathlib.Path, headers: list, row: list):
-    """
-    Helper function to write a single row to a CSV file.
-    Ensures directory exists and writes headers if the file is new.
-    """
-    try:
-        # Ensure the parent directory exists
-        path.parent.mkdir(parents=True, exist_ok=True)
-
-        file_exists = path.exists() # Check if file exists BEFORE opening in append mode
-
-        with open(path, "a", newline="") as f:
-            writer = csv.writer(f)
-            if not file_exists:
-                writer.writerow(headers) # Write headers only if file is new
-                logger_module_logger.info(f"Created new log file and wrote headers: {path}")
-            writer.writerow(row)
-    except IOError as e:
-        logger_module_logger.error(f"Failed to write to log file '{path}': {e}")
-    except Exception as e:
-        logger_module_logger.critical(f"An unexpected error occurred while writing to '{path}': {e}", exc_info=True)
+def _configure() -> None:
+    global _configured
+    if _configured:
+        return
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    handler = HashChainingHandler(str(LOG_PATH), CHAIN_PATH, when='midnight', backupCount=7)
+    handler.setFormatter(_FORMAT)
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.addHandler(handler)
+    _configured = True
 
 
-def _timestamp() -> str:
-    """Returns the current UTC timestamp in ISO 8601 format."""
-    return datetime.utcnow().isoformat()
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger with the given name after configuring logging."""
+    _configure()
+    return logging.getLogger(name)
 
-
-# Example Usage for Testing (remove for main integration)
-if __name__ == '__main__':
-    class MockStateManager:
-        def __init__(self):
-            # Define mock config values for log files and directory
-            self._config = {
-                'log_directory': './test_logs',
-                'sensor_log_file': 'test_data.csv',
-                'hvac_log_file': 'test_decisions.csv'
-            }
-            # Set up basic logging for the mock environment
-            logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-            logger_module_logger.setLevel(logging.DEBUG)
-
-            # Clean up old test log files and directory
-            if os.path.exists(self._config['log_directory']):
-                import shutil
-                shutil.rmtree(self._config['log_directory']) # Remove directory and its contents
-            os.makedirs(self._config['log_directory'])
-            logger_module_logger.info(f"Cleaned and created test log directory: {self._config['log_directory']}")
-
-
-        def get_value(self, key, default=None):
-            return self._config.get(key, default)
-
-        def set_value(self, key, value, bypass_validation=False):
-            self._config[key] = value
-            logger_module_logger.debug(f"MockStateManager: Set '{key}' to '{value}'")
-
-    print("--- Testing logger.py independently ---")
-    mock_sm = MockStateManager()
-
-    test_sensor_data_1 = {
-        'temperature': 22.1,
-        'humidity': 45.2,
-        'motion': True,
-        'status': 'VALID'
-    }
-    test_decision_1 = {
-        'hvac_state': 'OFF',
-        'mode': 'AUTO',
-        'cause': 'COMFORT_RANGE'
-    }
-
-    test_sensor_data_2 = {
-        'temperature': 19.5,
-        'humidity': 40.0,
-        'motion': True,
-        'status': 'VALID'
-    }
-    test_decision_2 = {
-        'hvac_state': 'HEAT_ON',
-        'mode': 'AUTO',
-        'cause': 'TEMP_LOW'
-    }
-
-    print("\n--- Logging first set of data ---")
-    log_sensor_data(test_sensor_data_1, mock_sm)
-    log_decision(test_sensor_data_1, test_decision_1, mock_sm)
-
-    print("\n--- Logging second set of data ---")
-    log_sensor_data(test_sensor_data_2, mock_sm)
-    log_decision(test_sensor_data_2, test_decision_2, mock_sm)
-
-    # Verify content of the test files
-    sensor_log_path = pathlib.Path(mock_sm.get_value('log_directory')) / mock_sm.get_value('sensor_log_file')
-    hvac_log_path = pathlib.Path(mock_sm.get_value('log_directory')) / mock_sm.get_value('hvac_log_file')
-
-    print(f"\nContents of {sensor_log_path}:")
-    with open(sensor_log_path, 'r') as f:
-        print(f.read())
-    
-    print(f"\nContents of {hvac_log_path}:")
-    with open(hvac_log_path, 'r') as f:
-        print(f.read())
-
-    # Clean up test log files and directory after testing
-    import shutil
-    if os.path.exists(mock_sm.get_value('log_directory')):
-        shutil.rmtree(mock_sm.get_value('log_directory'))
-
-    print("\nLogger tests complete.")

--- a/main.py
+++ b/main.py
@@ -1,195 +1,87 @@
-# /sz/src/main.py
-
-import time
-import logging
-import sys
-import threading
+"""SentientZone entry point."""
+import json
+import os
 import signal
+import time
+from datetime import datetime, timezone
+from pathlib import Path
 
-# Import core modules
+from sensors import SensorManager
+from control import HVACController
 from state_manager import StateManager
-from logger import setup_logging
-import sensor_reader
-import decision_engine
-import actuator_control
-import watchdog
-import button
-import rotator
-import report_generator
+from server import SentientZoneServer
+from button_override import OverrideButton
+from override_handler import OverrideManager
+from metrics import get_metrics
+from logger import get_logger
 
-# --- Global Variables ---
-app_state_manager: StateManager = None
-main_logger: logging.Logger = None
-running_event = threading.Event() # Event to signal threads to stop gracefully
 
-# --- Signal Handler for Graceful Shutdown ---
-def signal_handler(sig, frame):
-    global main_logger
-    if main_logger:
-        main_logger.info(f"Received signal {sig}. Initiating graceful shutdown...")
-    else:
-        print(f"Received signal {sig}. Initiating graceful shutdown...")
-    
-    running_event.set() # Set the event to signal threads to stop
-    sys.exit(0) # Exit the main process
 
-# Register signal handlers for graceful shutdown (e.g., Ctrl+C, systemd stop)
-signal.signal(signal.SIGINT, signal_handler)  # Ctrl+C
-signal.signal(signal.SIGTERM, signal_handler) # Systemd stop command
+LOG_PATH = '/home/pi/sz/logs/sentientzone.log'
 
-# --- Main Application Logic ---
+
 def main():
-    global app_state_manager, main_logger
+    logger = get_logger(__name__)
+    state = StateManager()
+    sensors = SensorManager(state.config)
+    hvac = HVACController(state.config)
+    override_mgr = OverrideManager(state)
+    server = SentientZoneServer(state, LOG_PATH, override_mgr)
+    server.start()
+    button = OverrideButton(state.config['pins']['button'], override_mgr)
+    button.start()
 
-    try:
-        # 1. Setup Logging
-        log_file = '/sz/logs/sentientzone.log'
-        setup_logging(log_file)
-        main_logger = logging.getLogger('MainApp')
-        main_logger.info("SentientZone application starting...")
+    metrics = get_metrics()
 
-        # 2. Initialize StateManager
-        config_file = '/sz/config/config.json'
-        app_state_manager = StateManager(config_file)
-        main_logger.info("StateManager initialized. Configuration loaded.")
+    running = True
 
-        # 3. Initialize Actuator Control
-        # This will configure GPIOs for controlling HVAC relays
-        if not actuator_control.setup_actuators(app_state_manager):
-            main_logger.critical("Failed to setup HVAC actuators. Exiting.")
-            running_event.set() # Signal immediate shutdown
-            return
-        main_logger.info("HVAC Actuator Control initialized.")
+    def handle_signal(sig, frame):
+        nonlocal running
+        running = False
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
 
-        # 4. Initialize Sensor Reader
-        # This will set up the connection for reading temp/humidity sensors
-        # This needs to be able to handle both wired and wireless sensors (via MQTT)
-        if not sensor_reader.setup_sensors(app_state_manager, running_event):
-            main_logger.critical("Failed to setup sensor reader. Exiting.")
-            running_event.set() # Signal immediate shutdown
-            return
-        main_logger.info("Sensor Reader initialized.")
+    motion_timeout = state.config.get('motion_timeout', 300)
+    last_motion = state.get('last_motion_ts') or 0
 
-        # 5. Initialize Watchdog
-        # This ensures the system self-restarts if the main loop hangs
-        watchdog_timeout_seconds = app_state_manager.get_value('watchdog_timeout_seconds', 300)
-        watchdog_period_seconds = app_state_manager.get_value('watchdog_period_seconds', 60)
-        watchdog.setup_watchdog(watchdog_timeout_seconds, watchdog_period_seconds)
-        main_logger.info(f"Watchdog initialized with timeout {watchdog_timeout_seconds}s and period {watchdog_period_seconds}s.")
-        watchdog.signal() # Initial signal to the watchdog
-
-        # 6. Initialize User Input Devices (Button and Rotary Encoder)
-        # These will run in separate threads to not block the main loop
-        if app_state_manager.get_value('button_enabled', False):
-            if not button.setup_button(app_state_manager, running_event):
-                 main_logger.warning("Failed to setup button input. Continuing without button.")
-            else:
-                main_logger.info("Button input initialized.")
-        
-        if app_state_manager.get_value('rotator_enabled', False):
-            if not rotator.setup_rotator(app_state_manager, running_event):
-                 main_logger.warning("Failed to setup rotary encoder. Continuing without rotator.")
-            else:
-                main_logger.info("Rotary encoder initialized.")
-
-        main_logger.info("All components initialized. Starting main loop...")
-
-        # --- Main Application Loop ---
-        loop_interval_seconds = app_state_manager.get_value('main_loop_interval_seconds', 10)
-        report_interval_minutes = app_state_manager.get_value('report_interval_minutes', 60)
-        last_report_time = time.time() # Track last report generation time
-
-        while not running_event.is_set(): # Loop until shutdown signal is received
-            start_loop_time = time.time()
-            main_logger.debug("Main loop iteration started.")
-
-            # 7. Read Sensor Data
-            # Sensor data is read by sensor_reader's internal loop (if wireless)
-            # or directly here (if wired, or just retrieve latest from internal buffer)
-            current_sensor_data = sensor_reader.get_latest_sensor_data(app_state_manager)
-            app_state_manager.set_value('current_sensor_data', current_sensor_data)
-            main_logger.debug(f"Latest sensor data: {current_sensor_data}")
-
-            # 8. Get HVAC Feedback (from actuator_control)
-            hvac_feedback = actuator_control.get_hvac_feedback()
-            app_state_manager.set_value('hvac_line_status', hvac_feedback)
-            main_logger.debug(f"HVAC line feedback: {hvac_feedback}")
-
-            # 9. Make Decision
-            # The decision engine uses sensor data, setpoints, current state from StateManager
-            desired_mode, desired_fan_state = decision_engine.make_decision(app_state_manager)
-            main_logger.debug(f"Decision: Mode={desired_mode}, Fan={desired_fan_state}")
-
-            # 10. Actuate HVAC
-            # Only send command if it's different from the currently commanded state
-            current_hvac_mode = app_state_manager.get_value('current_hvac_mode', 'OFF')
-            current_fan_state = app_state_manager.get_value('current_fan_state', 'AUTO')
-
-            if desired_mode != current_hvac_mode or desired_fan_state != current_fan_state:
-                actuator_control.set_hvac_state(desired_mode, desired_fan_state, app_state_manager)
-                main_logger.info(f"HVAC state changed to Mode: {desired_mode}, Fan: {desired_fan_state}")
-            else:
-                main_logger.debug("HVAC state unchanged.")
-
-            # 11. Generate Periodic Reports
-            if (time.time() - last_report_time) >= (report_interval_minutes * 60):
-                report_generator.generate_report(app_state_manager)
-                last_report_time = time.time()
-                main_logger.info("Generated periodic system report.")
-
-            # 12. Signal Watchdog
-            watchdog.signal()
-            main_logger.debug("Watchdog signaled.")
-
-            # 13. Maintain Loop Interval
-            elapsed_time = time.time() - start_loop_time
-            sleep_time = loop_interval_seconds - elapsed_time
-            if sleep_time > 0:
-                time.sleep(sleep_time)
-            else:
-                main_logger.warning(f"Main loop took too long ({elapsed_time:.2f}s). No sleep this iteration.")
-
-    except Exception as e:
-        if main_logger:
-            main_logger.critical(f"An unhandled error occurred in main loop: {e}", exc_info=True)
+    while running:
+        temp = sensors.read_temperature()
+        if temp is not None:
+            state.set('last_temp_f', temp)
+            metrics.record_temp(temp)
         else:
-            print(f"An unhandled error occurred before logger was fully initialized: {e}")
-            import traceback
-            traceback.print_exc()
+            metrics.increment_error()
+        if sensors.check_motion():
+            last_motion = time.time()
+        state.set('last_motion_ts', last_motion)
 
-    finally:
-        # --- Graceful Shutdown ---
-        if main_logger:
-            main_logger.info("Initiating final cleanup and shutdown procedures...")
+        now = datetime.now(timezone.utc)
+        override_mgr.clear_if_expired(now)
+        mode = state.get('current_mode', 'OFF')
+        if override_mgr.is_override_active(now):
+            mode = state.get('override_mode')
         else:
-            print("Initiating final cleanup and shutdown procedures...")
+            if temp is None:
+                mode = 'OFF'
+            elif (
+                temp > state.config['thresholds']['cool']
+                and time.time() - last_motion < motion_timeout
+            ):
+                mode = 'COOL_ON'
+            elif temp < state.config['thresholds']['heat']:
+                mode = 'HEAT_ON'
+            else:
+                mode = 'FAN_ONLY'
+        hvac.set_mode(mode)
+        state.set('current_mode', mode)
+        metrics.write_metrics(state)
+        time.sleep(state.config.get('loop_interval', 5))
 
-        # Signal all threads to stop
-        running_event.set()
+    logger.info('Shutting down')
+    hvac.set_mode('OFF')
+    hvac.cleanup()
+    sensors.cleanup()
 
-        # Stop and cleanup user input devices
-        if app_state_manager and app_state_manager.get_value('button_enabled', False):
-            button.cleanup_button()
-        if app_state_manager and app_state_manager.get_value('rotator_enabled', False):
-            rotator.cleanup_rotator()
-
-        # Cleanup actuator GPIOs (ensure HVAC is off)
-        actuator_control.cleanup_actuators()
-
-        # Cleanup sensor reader (e.g., MQTT client disconnect)
-        if app_state_manager and app_state_manager.get_value('sensor_reader_type', 'wired') == 'mqtt':
-            sensor_reader.disconnect_mqtt_client()
-        
-        # Save final state
-        if app_state_manager:
-            app_state_manager.save_config_debounced(force=True)
-            report_generator.generate_report(app_state_manager, final_report=True) # Generate final report
-            main_logger.info("Final state saved and report generated.")
-        
-        if main_logger:
-            main_logger.info("SentientZone application gracefully shut down.")
-        else:
-            print("SentientZone application gracefully shut down.")
 
 if __name__ == '__main__':
     main()

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,88 @@
+"""Metrics tracking for SentientZone."""
+
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from logger import get_logger
+
+
+METRICS_FILE = Path("/home/pi/sz/logs/metrics.json")
+
+
+class MetricsManager:
+    """Singleton class managing runtime metrics."""
+
+    _instance = None
+
+    def __new__(cls, path: Optional[Path] = None) -> "MetricsManager":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._init(path or METRICS_FILE)
+        return cls._instance
+
+    def _init(self, path: Path) -> None:
+        self.path = path
+        self.start = time.time()
+        self.error_count = 0
+        self.last_temp_f: Optional[float] = None
+        self.last_temp_time: Optional[float] = None
+        self.lock = threading.Lock()
+        self.logger = get_logger(__name__)
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Reset the singleton instance (for tests)."""
+        cls._instance = None
+
+    def record_temp(self, temp: float) -> None:
+        """Record the most recent temperature."""
+        with self.lock:
+            self.last_temp_f = temp
+            self.last_temp_time = time.time()
+
+    def increment_error(self) -> None:
+        """Increment error counter."""
+        with self.lock:
+            self.error_count += 1
+
+    def snapshot(self, state: Any) -> Dict[str, Any]:
+        """Return metrics snapshot dict."""
+        with self.lock:
+            data = {
+                "current_mode": state.get("current_mode"),
+                "last_temp_f": self.last_temp_f,
+                "override_active": state.get("override_mode") != "OFF",
+                "uptime_sec": int(time.time() - self.start),
+                "error_count": self.error_count,
+            }
+            return data
+
+    def write_metrics(self, state: Any) -> None:
+        """Write metrics snapshot atomically."""
+        data = self.snapshot(state)
+        tmp = self.path.with_suffix(".tmp")
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with open(tmp, "w") as f:
+                json.dump(data, f)
+            os.replace(tmp, self.path)
+        except Exception as exc:  # pragma: no cover - disk issues
+            self.logger.error("Failed to write metrics: %s", exc)
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+    def uptime(self) -> int:
+        """Return current uptime in seconds."""
+        return int(time.time() - self.start)
+
+
+def get_metrics(path: Optional[Path] = None) -> MetricsManager:
+    """Return the singleton metrics manager."""
+    return MetricsManager(path)
+

--- a/override_handler.py
+++ b/override_handler.py
@@ -1,0 +1,67 @@
+"""Override management for SentientZone."""
+
+from logger import get_logger
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from audit import log_override
+
+from dateutil import parser
+
+from state_manager import StateManager
+from control import VALID_MODES
+
+
+class OverrideManager:
+    """Manage temporary HVAC overrides."""
+
+    def __init__(self, state: StateManager) -> None:
+        self.state = state
+        self.logger = get_logger(__name__)
+
+    def is_override_active(self, now: datetime) -> bool:
+        """Return True if an override is currently active."""
+        mode = self.state.get("override_mode")
+        until = self.state.get("override_until")
+        if mode and mode != "OFF" and until:
+            try:
+                expiry = parser.isoparse(until)
+                return expiry > now
+            except (ValueError, TypeError):
+                self.logger.warning("Invalid override_until value: %s", until)
+        return False
+
+    def apply_override(self, mode: str, duration_minutes: int, source: str, initiated_by: str) -> None:
+        """Apply a new override mode for the given duration."""
+        if mode not in VALID_MODES:
+            self.logger.error("Invalid override mode: %s", mode)
+            raise ValueError(f"Invalid mode: {mode}")
+        expiry = datetime.now(timezone.utc) + timedelta(minutes=duration_minutes)
+        self.state.set("override_mode", mode)
+        self.state.set("override_until", expiry.isoformat())
+        self.logger.info(
+            "Override applied from %s by %s: %s until %s",
+            source,
+            initiated_by,
+            mode,
+            expiry.isoformat(),
+        )
+        log_override(mode, duration_minutes, source, initiated_by)
+
+    def clear_if_expired(self, now: datetime) -> None:
+        """Clear override if it has expired."""
+        until = self.state.get("override_until")
+        if not until:
+            return
+        try:
+            expiry = parser.isoparse(until)
+        except (ValueError, TypeError):
+            self.logger.warning("Invalid override_until value: %s", until)
+            self.state.set("override_mode", "OFF")
+            self.state.set("override_until", None)
+            return
+        if expiry <= now:
+            self.logger.info("Override expired at %s", until)
+            self.state.set("override_mode", "OFF")
+            self.state.set("override_until", None)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+python-dateutil
+adafruit-circuitpython-dht
+RPi.GPIO

--- a/sensors.py
+++ b/sensors.py
@@ -1,0 +1,53 @@
+"""Sensor interface for SentientZone."""
+import time
+from logger import get_logger
+try:
+    import board
+    import adafruit_dht
+    import RPi.GPIO as GPIO
+except Exception:  # pragma: no cover - hardware not present
+    board = None
+    adafruit_dht = None
+    GPIO = None
+
+
+class SensorManager:
+    """Read DHT22 temperature and PIR motion sensors."""
+
+    def __init__(self, config):
+        self.logger = get_logger(__name__)
+        self.dht_pin = config['pins']['dht']
+        self.motion_pin = config['pins']['motion']
+        self.dht_device = None
+        self.motion = False
+        if GPIO:
+            GPIO.setmode(GPIO.BCM)
+            GPIO.setup(self.motion_pin, GPIO.IN)
+        if adafruit_dht:
+            board_pin = getattr(board, f'D{self.dht_pin}', None) if board else None
+            self.dht_device = adafruit_dht.DHT22(board_pin if board_pin else self.dht_pin)
+
+    def read_temperature(self):
+        """Return temperature in Fahrenheit or None."""
+        if not self.dht_device:
+            return None
+        try:
+            temp_c = self.dht_device.temperature
+            if temp_c is None:
+                return None
+            return temp_c * 9 / 5 + 32
+        except Exception as exc:
+            self.logger.error("Temperature read failed: %s", exc)
+            return None
+
+    def check_motion(self):
+        """Return True if motion detected."""
+        if GPIO:
+            return GPIO.input(self.motion_pin) == GPIO.HIGH
+        return False
+
+    def cleanup(self):
+        if GPIO:
+            GPIO.cleanup(self.motion_pin)
+        if self.dht_device:
+            self.dht_device.exit()

--- a/server.py
+++ b/server.py
@@ -1,0 +1,120 @@
+"""Flask API for SentientZone with basic authentication and validation."""
+
+from logger import get_logger
+from typing import Any, Dict
+import time
+
+from metrics import get_metrics
+
+from flask import Flask, jsonify, request, send_file
+from threading import Thread
+
+from override_handler import OverrideManager
+
+
+class SentientZoneServer(Thread):
+    """Simple Flask server running in a thread."""
+
+    def __init__(self, state_manager, log_path: str, override_mgr: OverrideManager):
+        super().__init__(daemon=True)
+        self.state = state_manager
+        self.override_mgr = override_mgr
+        self.log_path = log_path
+        self.metrics = get_metrics()
+        self.app = Flask(__name__)
+        self.logger = get_logger(__name__)
+        self.api_key = self.state.config.get("api_key")
+        self._setup_routes()
+
+    def _setup_routes(self):
+        def require_key() -> Any:
+            """Validate X-API-Key header for POST requests."""
+            key = request.headers.get("X-API-Key")
+            if not self.api_key or key != self.api_key:
+                self.logger.warning(
+                    "Unauthorized request from %s", request.remote_addr
+                )
+                return jsonify({"error": "unauthorized"}), 401
+            return None
+
+        @self.app.route("/state")
+        def get_state():
+            return jsonify(self.state.state)
+
+        @self.app.route("/override", methods=["POST"])
+        def set_override():
+            auth_error = require_key()
+            if auth_error:
+                return auth_error
+            try:
+                data: Dict[str, Any] = request.get_json(force=True)
+            except Exception:
+                return jsonify({"error": "invalid json"}), 400
+            mode = data.get("mode")
+            duration = data.get("duration_minutes")
+            source = data.get("source", "api")
+            if mode not in {"COOL_ON", "HEAT_ON", "FAN_ONLY", "OFF"}:
+                return jsonify({"error": "invalid mode"}), 400
+            try:
+                duration = int(duration)
+            except (TypeError, ValueError):
+                return jsonify({"error": "invalid duration"}), 400
+            try:
+                self.override_mgr.apply_override(
+                    mode,
+                    duration,
+                    source,
+                    f"API@{request.remote_addr}",
+                )
+                self.logger.info(
+                    "Override from %s (%s): %s for %s min",
+                    request.remote_addr,
+                    source,
+                    mode,
+                    duration,
+                )
+                return jsonify({
+                    "override_mode": self.state.get("override_mode"),
+                    "override_until": self.state.get("override_until"),
+                })
+            except ValueError as exc:
+                self.logger.error("Override failed: %s", exc)
+                return jsonify({"error": str(exc)}), 400
+
+        @self.app.route("/logs")
+        def get_logs():
+            return send_file(self.log_path, mimetype="text/plain")
+
+        @self.app.route("/healthz")
+        def healthz():
+            reasons = []
+            now = time.time()
+            if not self.state:
+                reasons.append("state manager missing")
+            if not self.override_mgr:
+                reasons.append("override manager missing")
+            if self.metrics.last_temp_time is None:
+                reasons.append("no temp reading")
+            elif now - self.metrics.last_temp_time > 60:
+                reasons.append("stale sensor data")
+            ok = not reasons
+            if not ok:
+                self.logger.warning("Health check failed: %s", ", ".join(reasons))
+            payload = {
+                "status": "ok" if ok else "error",
+                "uptime_sec": self.metrics.uptime(),
+                "mode": self.state.get("current_mode"),
+                "last_temp_f": self.state.get("last_temp_f"),
+                "override_active": self.state.get("override_mode") != "OFF",
+                "errors": self.metrics.error_count,
+            }
+            return jsonify(payload), 200 if ok else 503
+
+        @self.app.errorhandler(Exception)
+        def handle_exception(exc: Exception):
+            self.logger.exception("Unhandled error: %s", exc)
+            return jsonify({"error": "internal server error"}), 500
+
+    def run(self):
+        self.logger.info("Starting Flask server on 127.0.0.1:8080")
+        self.app.run(host="127.0.0.1", port=8080)

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -euo pipefail
+
+LOGFILE="install.log"
+exec > >(tee -a "$LOGFILE") 2>&1
+
+BASE_DIR="/home/pi/sz"
+VENV_DIR="$BASE_DIR/venv"
+REQUIREMENTS="$BASE_DIR/requirements.txt"
+SERVICE_FILE="$BASE_DIR/sz_ui.service"
+STATE_DIR="$BASE_DIR/state"
+LOG_DIR="$BASE_DIR/logs"
+
+echo "Starting SentientZone setup..."
+
+# Create folders
+mkdir -p "$STATE_DIR" "$LOG_DIR"
+
+# Install system packages
+sudo apt-get update -y
+sudo apt-get install -y python3-venv python3-pip git raspi-gpio python3-rpi.gpio
+sudo pip3 install Adafruit_DHT
+
+# Create virtual environment
+if [ ! -d "$VENV_DIR" ]; then
+    python3 -m venv "$VENV_DIR"
+fi
+"$VENV_DIR/bin/pip" install --upgrade pip
+
+if [ -f "$REQUIREMENTS" ]; then
+    "$VENV_DIR/bin/pip" install -r "$REQUIREMENTS"
+fi
+
+# Install systemd service
+sudo cp "$SERVICE_FILE" /etc/systemd/system/sz_ui.service
+sudo systemctl daemon-reload
+sudo systemctl enable sz_ui.service
+sudo systemctl restart sz_ui.service
+
+echo "SentientZone setup complete."
+

--- a/state/state.json
+++ b/state/state.json
@@ -1,0 +1,7 @@
+{
+    "override_mode": "OFF",
+    "override_until": null,
+    "last_temp_f": null,
+    "last_motion_ts": null,
+    "current_mode": "OFF"
+}

--- a/state/state_backup.json
+++ b/state/state_backup.json
@@ -1,0 +1,7 @@
+{
+    "override_mode": "OFF",
+    "override_until": null,
+    "last_temp_f": null,
+    "last_motion_ts": null,
+    "current_mode": "OFF"
+}

--- a/state_manager.py
+++ b/state_manager.py
@@ -1,534 +1,91 @@
-```python
+"""Persistent state manager with validation and recovery."""
+
 import json
+from logger import get_logger
 import os
 import threading
-import time
-from datetime import datetime
-import uuid
-import logging
-
-# --- Setup Logging for State Manager ---
-# This logger is specifically for the State Manager module.
-# In a full "iron-clad" system, you'd typically have a centralized logging setup
-# (e.g., configured in your main application entry point)
-# where this logger contributes to a main application logger.
-# For now, it logs to console/basic stream.
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-state_manager_logger = logging.getLogger('StateManager')
+from pathlib import Path
+from typing import Any, Dict
 
 
 class StateManager:
-    """
-    Manages all configuration and runtime state for the HVAC controller.
-    Ensures thread-safe access, robust persistence, and data validation.
-    This class is designed to be the single source of truth for the application's state.
-    """
+    """Manage configuration and runtime state for SentientZone."""
 
-    CONFIG_FILE = 'config.json'
-    # The time delay (in seconds) before a pending save operation actually writes to disk.
-    # This is crucial for SD card endurance on Raspberry Pis, preventing excessive writes.
-    # If a new change comes in before this debounce time, the timer resets.
-    # We chose 30 seconds as a balance between persistence and write wear.
-    # A shorter time means faster persistence of changes but more writes.
-    SAVE_DEBOUNCE_TIME_SEC = 30
-
-    # This dictionary defines the default, pristine state of the controller.
-    # It's used when no config file exists or when a corrupted one is found.
-    # New features should add their default values here for forward compatibility.
-    DEFAULT_CONFIG = {
-        # A unique identifier for this specific Raspberry Pi/HVAC zone.
-        # Essential for multi-zone deployments and data aggregation later.
-        # If not found or explicitly None, a new UUID will be generated on first load.
-        'controller_id': None,
-        'comfort_min_c': 20.0,  # Minimum desired temperature in Celsius
-        'comfort_max_c': 24.0,  # Maximum desired temperature in Celsius
-        'current_mode': 'auto',  # The active operational mode: 'auto', 'manual', or 'schedule'
-        'manual_state': 'off',  # 'on' or 'off' when in 'manual' mode
-        'schedules': [],  # A list of dictionaries, each representing a schedule entry.
-                          # Example: {'name': 'Morning', 'start_time': '07:00', 'end_time': '09:00', 'temp_target': 22.0}
-                          # **Larger Implementation Note:** Detailed validation of schedule format (e.g., valid time strings,
-                          # non-overlapping times) is crucial but primarily handled by the UI or the Schedule Manager,
-                          # not directly by the basic validation here. The StateManager just stores what it's given.
-        'relay_pin': 17,  # BCM GPIO pin number connected to the HVAC relay module.
-                          # **Uncertainty/Assumptions:** This assumes you're using BCM numbering.
-                          # Also, the exact pin depends on your wiring. Make sure this matches!
-        'dht_pin': 4,  # BCM GPIO pin number for the DHT22 data line.
-                        # **Uncertainty/Assumptions:** Assumes you're using BCM numbering.
-                        # Check your DHT22 wiring.
-        'pir_pin': 27,  # BCM GPIO pin number for the PIR motion sensor output.
-                        # **Uncertainty/Assumptions:** Assumes you're using BCM numbering.
-                        # Check your PIR wiring.
-        'button_gpio_pin': 26, # BCM pin for override button
-        'sensor_poll_interval_sec': 30,  # How often (in seconds) the system reads sensor data.
-                                         # Too frequent could waste CPU, too infrequent might miss rapid changes.
-        'minimum_run_time_sec': 180,  # Minimum time (in seconds) the HVAC must run once turned on.
-                                      # This is critical to protect compressors and prevent "short cycling."
-                                      # 3 minutes (180s) is a common protective minimum.
-        'minimum_off_time_sec': 180,  # Minimum time (in seconds) the HVAC must remain off after being turned off.
-                                      # Also crucial for compressor protection.
-        'dht_temp_offset': 0.0,  # A calibration offset (in Celsius) to adjust DHT22 readings.
-                                  # Useful if your sensor is consistently slightly off.
-        'override_schedule': False,  # A future-ready flag; potentially allows a master control to temporarily
-                                      # bypass specific zone schedules without changing them.
-        'last_known_temp': None,  # Stores the last valid temperature reading.
-                                  # Used for graceful degradation if the DHT22 sensor temporarily fails.
-                                  # The Sensor Manager module would be responsible for updating this.
-        'last_known_humidity': None, # Stores the last valid humidity reading.
-                                     # Used for graceful degradation if the DHT22 sensor temporarily fails.
-        'hvac_status': 'unknown' # Current operational state of the HVAC system ('on', 'off', 'unknown').
-                                 # This reflects the state the Actuator Control is trying to maintain.
-        'log_retention_days': 30, # Default to keep logs for 30 days
+    DEFAULT_STATE: Dict[str, Any] = {
+        "override_mode": "OFF",
+        "override_until": None,
+        "last_temp_f": None,
+        "last_motion_ts": None,
+        "current_mode": "OFF",
     }
 
-    def __init__(self):
-        self._config = {}  # The internal dictionary holding the live application state.
-        self._lock = threading.Lock()  # A threading lock to ensure only one thread can access/modify
-                                       # _config at any given time. This prevents race conditions.
-        self._last_save_time = 0       # Monotonic timestamp of the last successful disk save.
-        self._pending_save = False     # Flag to indicate if a save has been requested and is awaiting debounce.
+    def __init__(self, config_path: str = "config/config.json",
+                 state_path: str = "state/state.json") -> None:
+        self.config_path = Path(config_path)
+        self.state_path = Path(state_path)
+        self.backup_path = self.state_path.parent / "state_backup.json"
+        self._lock = threading.Lock()
+        self.logger = get_logger(__name__)
+        self.config = self._load_json(self.config_path, {})
+        self.state = self._load_state()
 
-        # On initialization, immediately try to load the configuration from disk.
-        self._load_config()
-
-    def _load_config(self):
-        """
-        Loads configuration from the specified CONFIG_FILE.
-        Handles scenarios where the file doesn't exist, is corrupted, or needs merging with new defaults.
-        This method operates while holding the internal lock.
-        """
-        with self._lock: # Acquire the lock to ensure no other thread tries to access config during load.
-            if not os.path.exists(self.CONFIG_FILE):
-                # If no config file is found, start with the default configuration.
-                self._config = self.DEFAULT_CONFIG.copy()
-                if self._config['controller_id'] is None:
-                    self._config['controller_id'] = str(uuid.uuid4()) # Generate a unique ID for this controller.
-                state_manager_logger.info(f"Config file '{self.CONFIG_FILE}' not found. Created default config.")
-                self._save_config_immediate() # Immediately save the new default config to disk.
-                return
-
+    def _load_json(self, path: Path, default: Dict[str, Any]) -> Dict[str, Any]:
+        if path.exists():
             try:
-                # Attempt to load the JSON configuration file.
-                with open(self.CONFIG_FILE, 'r') as f:
-                    loaded_config = json.load(f)
+                with open(path, "r") as file:
+                    return json.load(file)
+            except Exception as exc:  # pragma: no cover - file may be corrupted
+                self.logger.exception("Failed loading %s: %s", path, exc)
+        return default.copy()
 
-                # Merge the loaded configuration with the default configuration.
-                # This ensures that if new default keys are added in software updates,
-                # they will be present in the loaded configuration. Existing user settings are preserved.
-                self._config = self._merge_configs(self.DEFAULT_CONFIG.copy(), loaded_config)
+    def _load_state(self) -> Dict[str, Any]:
+        data = self._load_json(self.state_path, self.DEFAULT_STATE)
+        if set(data.keys()) != set(self.DEFAULT_STATE.keys()):
+            self.logger.warning("State schema mismatch. Resetting state.")
+            data = self.DEFAULT_STATE.copy()
+            self._write_state(data)
+        return data
 
-                # Ensure controller_id exists. If it was missing in the loaded file (e.g., old version), generate it.
-                if self._config.get('controller_id') is None:
-                    self._config['controller_id'] = str(uuid.uuid4())
-                    state_manager_logger.info("Generated new controller_id as it was missing in loaded config.")
-
-                state_manager_logger.info(f"Config loaded successfully from '{self.CONFIG_FILE}'.")
-                # Immediately save the merged config. This ensures the disk file always reflects
-                # the latest schema (with new defaults added) after a load.
-                self._save_config_immediate()
-            except (json.JSONDecodeError, IOError) as e:
-                # This block handles file corruption (JSONDecodeError) or basic file I/O errors.
-                timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
-                corrupt_file = f"{self.CONFIG_FILE}.corrupt.{timestamp}"
-                try:
-                    # Attempt to rename the corrupted file for debugging purposes.
-                    os.rename(self.CONFIG_FILE, corrupt_file)
-                    state_manager_logger.warning(
-                        f"Config file '{self.CONFIG_FILE}' corrupted or unreadable: {e}. "
-                        f"Renamed to '{corrupt_file}' and loaded default config."
-                    )
-                except OSError as rename_e:
-                    # If renaming fails (e.g., permission issues), log an error but still proceed with defaults.
-                    state_manager_logger.error(
-                        f"Could not rename corrupted config file '{self.CONFIG_FILE}': {rename_e}. "
-                        "Loading default config anyway."
-                    )
-                # Fallback: Load the default configuration as a clean slate.
-                self._config = self.DEFAULT_CONFIG.copy()
-                if self._config['controller_id'] is None: # Double-check in case default also missing
-                    self._config['controller_id'] = str(uuid.uuid4())
-                # Immediately save the default config to ensure a valid file exists on disk.
-                self._save_config_immediate()
-
-    def _merge_configs(self, default, loaded):
-        """
-        Recursively merges a loaded configuration dictionary into a default configuration.
-        Existing keys in 'loaded' override values in 'default'.
-        New keys in 'default' that are not in 'loaded' are retained.
-        This handles forward compatibility for new features.
-        """
-        for key, default_value in default.items():
-            if key in loaded:
-                if isinstance(default_value, dict) and isinstance(loaded[key], dict):
-                    # If both values are dictionaries, recurse to merge nested configurations.
-                    default[key] = self._merge_configs(default_value, loaded[key])
-                else:
-                    # For non-dictionary values, the loaded value takes precedence.
-                    default[key] = loaded[key]
-        return default
-
-    def _save_config_immediate(self):
-        """
-        Saves the current configuration to disk immediately using an atomic write operation.
-        This method is designed to be called internally (e.g., by _load_config or save_config_debounced)
-        and *assumes the internal lock (`_lock`) is already acquired by the caller*.
-        This prevents race conditions during the actual file write.
-        """
-        temp_file = self.CONFIG_FILE + '.tmp'
+    def _write_state(self, data: Dict[str, Any]) -> None:
+        tmp_path = self.state_path.with_suffix(".tmp")
         try:
-            # 1. Write to a temporary file first.
-            with open(temp_file, 'w') as f:
-                json.dump(self._config, f, indent=4)
-            # 2. Atomically replace the old config file with the new temporary file.
-            # os.replace() is atomic on POSIX systems (Linux/Raspberry Pi) and robust against power failures.
-            # This ensures that either the old valid config or the new valid config is always present,
-            # preventing corrupted files if the save operation is interrupted.
-            os.replace(temp_file, self.CONFIG_FILE)
-            self._last_save_time = time.monotonic() # Update the timestamp of the last save.
-            self._pending_save = False # Clear the pending save flag as the save is complete.
-            state_manager_logger.debug(f"Config saved immediately to '{self.CONFIG_FILE}'.")
-        except IOError as e:
-            # Log an error if the file write or replace operation fails.
-            state_manager_logger.error(f"Failed to save config file '{self.CONFIG_FILE}': {e}")
-        finally:
-            # Always attempt to clean up the temporary file, even if the save failed.
-            if os.path.exists(temp_file):
+            with open(tmp_path, "w") as tmp_file:
+                json.dump(data, tmp_file, indent=4)
+            if self.state_path.exists():
                 try:
-                    os.remove(temp_file)
-                except OSError as e:
-                    state_manager_logger.warning(f"Failed to clean up temp config file '{temp_file}': {e}")
+                    with open(self.state_path, "r") as src, open(self.backup_path, "w") as dst:
+                        dst.write(src.read())
+                except Exception as exc:  # pragma: no cover - file may not exist
+                    self.logger.exception("Failed to create backup: %s", exc)
+            os.replace(tmp_path, self.state_path)
+        except Exception as exc:  # pragma: no cover - disk issues
+            self.logger.exception("Failed writing state file: %s", exc)
+            if tmp_path.exists():
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
 
+    def save_state(self) -> None:
+        """Persist current state atomically with backup."""
+        with self._lock:
+            self._write_state(self.state)
 
-    def save_config_debounced(self, force=False):
-        """
-        Requests a save of the configuration to disk. This method incorporates a debounce timer
-        to limit the frequency of disk writes, which is important for extending the life
-        of the Raspberry Pi's SD card.
+    def get(self, key: str) -> Any:
+        """Thread-safe retrieval of a state value."""
+        with self._lock:
+            return self.state.get(key)
 
-        Args:
-            force (bool): If True, bypasses the debounce timer and forces an immediate save.
-                          Use this for critical situations like graceful shutdown or
-                          when an immediate write is absolutely necessary.
-        """
-        with self._lock: # Acquire the lock to safely check and modify save state.
-            if force:
-                self._save_config_immediate()
-                state_manager_logger.info("Config forced saved.")
-                return
+    def set(self, key: str, value: Any) -> None:
+        """Update a state value and persist it."""
+        if key not in self.DEFAULT_STATE:
+            raise KeyError(f"Unknown state key: {key}")
+        with self._lock:
+            self.state[key] = value
+            self._write_state(self.state)
 
-            self._pending_save = True # Mark that a save is needed.
-            current_time = time.monotonic() # Get current monotonic time (unaffected by system clock changes).
-            if (current_time - self._last_save_time) >= self.SAVE_DEBOUNCE_TIME_SEC:
-                # If enough time has passed since the last save, perform an immediate save.
-                self._save_config_immediate()
-                state_manager_logger.debug("Config saved due to debounce timer.")
-            else:
-                # If not enough time has passed, the save is "debounced" and will happen later
-                # when the timer expires (assuming a continuous check by the main loop,
-                # or triggered by a subsequent set_value call after the timer expires).
-                # **Larger Implementation Note:** For true robustness, a dedicated background thread
-                # that periodically checks `_pending_save` and `_last_save_time` to trigger saves
-                # might be considered, ensuring saves happen even if no new `set_value` calls occur.
-                # For this design, we rely on `set_value` calls eventually triggering the save.
-                state_manager_logger.debug("Config save debounced.")
-
-    def get_config(self):
-        """
-        Returns a deep copy of the entire current configuration.
-        This ensures that external modules get a snapshot of the config
-        and cannot directly modify the internal state, preserving thread safety.
-        """
-        with self._lock: # Acquire the lock to safely read the configuration.
-            # Using json.loads(json.dumps()) is a common and simple way to create a deep copy
-            # of a JSON-serializable dictionary.
-            return json.loads(json.dumps(self._config))
-
-    def get_value(self, key, default=None):
-        """
-        Safely retrieves a single value from the configuration by its key.
-        Returns the default value if the key is not found.
-        """
-        with self._lock: # Acquire the lock to safely read the configuration.
-            return self._config.get(key, default)
-
-    def set_value(self, key, value, bypass_validation=False):
-        """
-        Safely sets a single value in the configuration.
-        Includes crucial input validation before accepting the value.
-
-        Args:
-            key (str): The configuration key to set.
-            value: The new value for the key.
-            bypass_validation (bool): Set to True ONLY for internal use (e.g., during _load_config)
-                                      where values are known to be valid or are being transformed.
-                                      NEVER use this for user-provided inputs.
-
-        Returns:
-            bool: True if the value was successfully set (and validated), False otherwise.
-        """
-        if not bypass_validation and not self._validate_value(key, value):
-            state_manager_logger.warning(f"Validation failed for key '{key}' with value '{value}'. Not setting.")
-            return False
-
-        with self._lock: # Acquire the lock to safely modify the configuration.
-            if key in self._config and self._config[key] == value:
-                # Optimization: If the value hasn't actually changed, no need to update or save.
-                return True
-
-            self._config[key] = value
-            self.save_config_debounced() # Request a debounced save after the change.
-            state_manager_logger.debug(f"Key '{key}' set to '{value}'.")
-            return True
-
-    def update_values(self, updates: dict):
-        """
-        Updates multiple values in the configuration atomically.
-        All provided values are validated before any changes are applied.
-        If any value fails validation, it's skipped, but other valid updates proceed.
-
-        Args:
-            updates (dict): A dictionary of key-value pairs to update.
-
-        Returns:
-            bool: True if any values were successfully updated, False otherwise.
-        """
-        validated_updates = {}
-        for key, value in updates.items():
-            if not self._validate_value(key, value):
-                state_manager_logger.warning(f"Validation failed for key '{key}' with value '{value}'. Skipping update for this key.")
-            else:
-                validated_updates[key] = value
-
-        if not validated_updates:
-            state_manager_logger.info("No valid updates to apply.")
-            return False
-
-        with self._lock: # Acquire the lock for the entire batch update.
-            changed = False
-            for key, value in validated_updates.items():
-                if self._config.get(key) != value:
-                    self._config[key] = value
-                    changed = True
-                    state_manager_logger.debug(f"Key '{key}' updated to '{value}'.")
-            if changed:
-                self.save_config_debounced() # Request a debounced save if any changes were made.
-                return True
-            return False
-
-    def _validate_value(self, key, value):
-        """
-        Performs type and range validation for specific configuration keys.
-        This is a critical part of the "iron-clad" design, preventing invalid data from
-        corrupting the system's state.
-
-        Returns:
-            bool: True if the value is valid for the given key, False otherwise.
-        """
-        if key == 'comfort_min_c' or key == 'comfort_max_c':
-            if not isinstance(value, (float, int)):
-                state_manager_logger.error(f"Validation Error: '{key}' must be a number, got '{type(value)}'.")
-                return False
-            # These ranges are assumptions about typical commercial HVAC temperature requirements.
-            # **Uncertainty/Assumptions:** You might need to adjust these ranges based on specific
-            # industry standards, building codes, or client requirements.
-            if not (0.0 <= value <= 45.0): # Allowing a broader range for control (0-45C)
-                state_manager_logger.warning(f"Validation Warning: Temperature '{key}' ({value}C) is outside typical comfort range [0.0, 45.0] but within control limits.")
-            return True
-        elif key in ['current_mode']:
-            if value not in ['auto', 'manual', 'schedule']:
-                state_manager_logger.error(f"Validation Error: '{key}' must be 'auto', 'manual', or 'schedule', got '{value}'.")
-                return False
-            return True
-        elif key in ['manual_state', 'hvac_status']:
-            if value not in ['on', 'off', 'unknown']:
-                state_manager_logger.error(f"Validation Error: '{key}' must be 'on', 'off', or 'unknown', got '{value}'.")
-                return False
-            return True
-        elif key in ['relay_pin', 'dht_pin', 'pir_pin']:
-            if not isinstance(value, int) or not (0 <= value <= 40): # Typical BCM GPIO pin range on Raspberry Pi.
-                # **Uncertainty/Assumptions:** This range covers most standard Raspberry Pi GPIO pins.
-                # Ensure your specific Pi model and any HATs/expansion boards use pins within this range.
-                state_manager_logger.error(f"Validation Error: GPIO pin '{key}' ({value}) invalid or out of typical BCM range [0, 40].")
-                return False
-            return True
-        elif key == 'controller_id':
-            # controller_id is typically generated internally or managed by a deployment system.
-            # Basic validation: it should be a non-empty string. UUID format check could be added.
-            if not isinstance(value, str) or len(value) == 0:
-                state_manager_logger.error(f"Validation Error: '{key}' must be a non-empty string, got '{value}'.")
-                return False
-            return True
-        elif key == 'button_gpio_pin':
-            if not isinstance(value, int) or not (0 <= value <= 40):
-                state_manager_logger.error(f"Validation Error: GPIO pin '{key}' ({value}) invalid or out of typical BCM range [0, 40].")
-                return False
-            return True
-        elif key == 'sensor_poll_interval_sec':
-            if not isinstance(value, int) or not (5 <= value <= 600): # Allow 5 seconds to 10 minutes polling.
-                state_manager_logger.error(f"Validation Error: '{key}' must be an integer between 5 and 600, got '{value}'.")
-                return False
-            return True
-        elif key in ['minimum_run_time_sec', 'minimum_off_time_sec']:
-            if not isinstance(value, int) or not (0 <= value <= 3600): # Allow 0 seconds (disable) to 1 hour (3600s).
-                state_manager_logger.error(f"Validation Error: '{key}' must be an integer between 0 and 3600, got '{value}'.")
-                return False
-            return True
-        elif key == 'dht_temp_offset':
-            if not isinstance(value, (float, int)) or not (-5.0 <= value <= 5.0): # Reasonable offset range for calibration.
-                state_manager_logger.error(f"Validation Error: '{key}' must be a number between -5.0 and 5.0, got '{value}'.")
-                return False
-            return True
-        elif key == 'log_retention_days':
-            if not isinstance(value, int) or not (1 <= value <= 365): # Example range
-                state_manager_logger.error(f"Validation Error: Log retention days '{key}' ({value}) invalid or out of typical range [1, 365].")
-                return False
-            return True
-        elif key == 'override_schedule':
-            if not isinstance(value, bool):
-                state_manager_logger.error(f"Validation Error: '{key}' must be a boolean, got '{value}'.")
-                return False
-            return True
-        elif key in ['last_known_temp', 'last_known_humidity']:
-            # These values are updated internally by sensor readings; they can be None if unknown/failed.
-            if value is not None and not isinstance(value, (float, int)):
-                state_manager_logger.error(f"Validation Error: '{key}' must be a number or None, got '{value}'.")
-                return False
-            return True
-        elif key == 'schedules':
-            # **Larger Implementation Note:** This validation is relatively basic for a list of schedules.
-            # For a truly "iron-clad" system managing complex commercial schedules, you would want:
-            # 1. More detailed validation of each schedule dictionary's structure (name, start_time, end_time, temp_target).
-            # 2. Validation of time formats (e.g., "HH:MM").
-            # 3. Logic to check for overlapping schedules within the list.
-            # 4. Range checks for `temp_target` within schedules.
-            # These complex validations are typically handled by a dedicated 'Schedule Manager' module
-            # or the UI itself *before* trying to pass the list to the StateManager.
-            if not isinstance(value, list):
-                state_manager_logger.error(f"Validation Error: '{key}' must be a list, got '{type(value)}'.")
-                return False
-            return True # Assuming individual schedule items are validated elsewhere if needed.
-        else:
-            # **Uncertainty/Assumptions:** For any key not explicitly defined in the validation rules,
-            # this defaults to True. This allows for adding new keys to DEFAULT_CONFIG without
-            # immediately requiring validation logic here. However, for maximum "iron-clad" security,
-            # you might want to enforce explicit validation for *all* keys to prevent unexpected data types.
-            state_manager_logger.warning(f"Validation Warning: No explicit validation rule for key '{key}'. Proceeding assuming valid.")
-            return True
-
-# --- Example Usage for Testing and Integration ---
-# This block demonstrates how the StateManager works in isolation.
-# It simulates various scenarios like first-time load, setting values,
-# testing debounce, handling corruption, and forward compatibility.
-# You would remove or comment out this block when integrating into your main application.
-if __name__ == "__main__":
-    # Ensure a clean slate for testing by deleting any existing config files.
-    if os.path.exists(StateManager.CONFIG_FILE):
-        os.remove(StateManager.CONFIG_FILE)
-    if os.path.exists(StateManager.CONFIG_FILE + '.tmp'):
-        os.remove(StateManager.CONFIG_FILE + '.tmp')
-    # Clean up any previously created corrupted files from past tests.
-    for f in os.listdir('.'):
-        if f.startswith(StateManager.CONFIG_FILE + '.corrupt.'):
-            os.remove(f)
-
-    print("--- Test 1: Initial load (no file) ---")
-    # First time loading should create a default config.json and generate a controller_id.
-    sm = StateManager()
-    initial_config = sm.get_config()
-    print(f"Initial config loaded: {initial_config}")
-    assert initial_config['current_mode'] == 'auto'
-    assert isinstance(initial_config['controller_id'], str) # Check that a UUID was generated.
-    assert os.path.exists(StateManager.CONFIG_FILE) # Verify config file was created.
-
-    print("\n--- Test 2: Set values and trigger debounced save ---")
-    sm.set_value('comfort_min_c', 21.0)
-    sm.set_value('current_mode', 'manual')
-    sm.set_value('manual_state', 'on')
-    # These calls should trigger internal flags for debounced saving.
-    # The file might not be immediately updated on disk due to the debounce timer.
-
-    print("\n--- Test 3: Validate input (should fail and log warnings) ---")
-    sm.set_value('comfort_min_c', 'twenty') # This should fail validation (wrong type).
-    sm.set_value('relay_pin', 999) # This should fail validation (out of typical GPIO range).
-    sm.set_value('current_mode', 'invalid_mode') # This should fail validation (invalid option).
-
-    # Verify that the values that failed validation were NOT changed.
-    current_config = sm.get_config()
-    assert current_config['comfort_min_c'] == 21.0 # Should remain 21.0
-    assert current_config['relay_pin'] == StateManager.DEFAULT_CONFIG['relay_pin'] # Should revert/stay at default
-    assert current_config['current_mode'] == 'manual' # Should remain 'manual'
-
-    # Add a schedule to the list.
-    # **Important Note on Lists/Dictionaries:** When modifying mutable objects (like lists or dictionaries)
-    # returned by `get_value` or `get_config`, you must re-`set_value` the entire object
-    # back into the StateManager for the changes to be recognized and persisted.
-    print("\n--- Test 4: Add a schedule ---")
-    current_schedules = sm.get_value('schedules')
-    new_schedule = {'name': 'Evening', 'start_time': '18:00', 'end_time': '22:00', 'temp_target': 23.5}
-    current_schedules.append(new_schedule)
-    sm.set_value('schedules', current_schedules) # Re-set the entire list to trigger save.
-
-    # Force a save to ensure all changes from previous steps are written to disk
-    # before the next test (which simulates a new startup).
-    sm.save_config_debounced(force=True)
-    time.sleep(1) # Give a moment for file operations to complete.
-
-    print("\n--- Test 5: Load existing config from disk ---")
-    # Create a new StateManager instance to simulate a fresh application startup.
-    sm2 = StateManager()
-    loaded_config = sm2.get_config()
-    print(f"Loaded config: {loaded_config}")
-    assert loaded_config['comfort_min_c'] == 21.0
-    assert loaded_config['current_mode'] == 'manual'
-    assert loaded_config['manual_state'] == 'on'
-    assert len(loaded_config['schedules']) == 1
-    assert loaded_config['schedules'][0]['name'] == 'Evening'
-
-    print("\n--- Test 6: Test corrupted file recovery (manually create a bad file) ---")
-    # Intentionally corrupt the config file to test error handling.
-    with open(StateManager.CONFIG_FILE, 'w') as f:
-        f.write("{invalid json")
-    sm3 = StateManager()
-    corrupted_load_config = sm3.get_config()
-    print(f"Loaded config after corruption: {corrupted_load_config}")
-    # Verify that the system reverted to default configuration after detecting corruption.
-    assert corrupted_load_config == StateManager.DEFAULT_CONFIG
-    # Verify that the corrupted file was renamed with a timestamp.
-    # (Note: The exact timestamp will vary, so we check for presence and prefix).
-    assert any(f.startswith(f"{StateManager.CONFIG_FILE}.corrupt.") for f in os.listdir('.'))
-
-    print("\n--- Test 7: Forward compatibility (add a new default key, then load an old config) ---")
-    # Simulate an old config file that doesn't have a 'new_feature_setting'.
-    old_config_content = {
-        'comfort_min_c': 19.0,
-        'current_mode': 'auto',
-        'controller_id': 'test-old-id'
-    }
-    with open(StateManager.CONFIG_FILE, 'w') as f:
-        json.dump(old_config_content, f)
-
-    # Temporarily add a new key to DEFAULT_CONFIG to simulate a software update.
-    StateManager.DEFAULT_CONFIG['new_feature_setting'] = 'default_value_for_new_feature'
-    sm4 = StateManager()
-    forward_compatible_config = sm4.get_config()
-    print(f"Forward compatible config: {forward_compatible_config}")
-    # Verify that the old settings are preserved and the new default key is added.
-    assert forward_compatible_config['comfort_min_c'] == 19.0
-    assert forward_compatible_config['new_feature_setting'] == 'default_value_for_new_feature'
-    assert forward_compatible_config['controller_id'] == 'test-old-id'
-    # Clean up the temporary modification to DEFAULT_CONFIG for subsequent runs.
-    del StateManager.DEFAULT_CONFIG['new_feature_setting']
-
-    print("\nAll StateManager tests passed successfully!")
-    print("Remember to integrate this `StateManager` class into your main application's logic.")
-    print("You'll instantiate it once and pass its instance to other modules as needed.")
-
-    # Final cleanup of all test files.
-    if os.path.exists(StateManager.CONFIG_FILE):
-        os.remove(StateManager.CONFIG_FILE)
-    if os.path.exists(StateManager.CONFIG_FILE + '.tmp'):
-        os.remove(StateManager.CONFIG_FILE + '.tmp')
-    for f in os.listdir('.'):
-        if f.startswith(StateManager.CONFIG_FILE + '.corrupt.'):
-            os.remove(f)
-
-```
+    def reset_state(self) -> None:
+        """Reset state to default values and persist."""
+        with self._lock:
+            self.state = self.DEFAULT_STATE.copy()
+            self._write_state(self.state)

--- a/sz_ui.service
+++ b/sz_ui.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=SentientZone HVAC Controller
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/home/pi/sz/venv/bin/python /home/pi/sz/main.py
+WorkingDirectory=/home/pi/sz
+Restart=on-failure
+User=pi
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=multi-user.target
+

--- a/test_mode.py
+++ b/test_mode.py
@@ -12,11 +12,14 @@ Behavior:
 - Emulates sensor_reader.read_sensors()
 - Cycles through fake inputs and prints decisions
 """
+__test__ = False
 
 import time
 from decision_engine import decide_hvac_action
 from override_manager import get_override_mode
-from logger import log_sensor_data, log_decision
+from logger import get_logger
+
+logger = get_logger(__name__)
 
 # Test scenario: cycle through common input states
 TEST_SEQUENCE = [
@@ -37,8 +40,8 @@ def run_test_cycle(interval_sec=2):
         override_mode = get_override_mode()
         decision = decide_hvac_action(fake, override_mode)
 
-        log_sensor_data(fake)
-        log_decision(fake, decision)
+        logger.info("Sensor: %s", fake)
+        logger.info("Decision: %s", decision)
 
         print(f"Sensor: {fake}")
         print(f"Decision: {decision}")

--- a/tests/mocks/mock_hardware.py
+++ b/tests/mocks/mock_hardware.py
@@ -1,0 +1,9 @@
+class MockHardwareInterface:
+    def __init__(self, *args, **kwargs):
+        self.actions = []
+    def activate(self, pin_name):
+        self.actions.append(f"on:{pin_name}")
+    def deactivate_all(self):
+        self.actions.append("off:all")
+    def cleanup(self):
+        self.actions.append("cleanup")

--- a/tests/mocks/mock_sensors.py
+++ b/tests/mocks/mock_sensors.py
@@ -1,0 +1,14 @@
+class MockSensorReader:
+    def __init__(self, temperature=None, motion=False):
+        self.temperature = temperature
+        self.motion = motion
+        self.temp_calls = 0
+        self.motion_calls = 0
+    def read_temperature(self):
+        self.temp_calls += 1
+        return self.temperature
+    def check_motion(self):
+        self.motion_calls += 1
+        return self.motion
+    def cleanup(self):
+        pass

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -1,0 +1,28 @@
+from control import HVACController
+from tests.mocks.mock_hardware import MockHardwareInterface
+
+
+def sample_config():
+    return {"pins": {"cooling": 17, "heating": 27, "fan": 22}}
+
+
+def test_set_modes():
+    mock_hw = MockHardwareInterface()
+    ctrl = HVACController(sample_config(), hardware=mock_hw)
+    ctrl.set_mode("COOL_ON")
+    assert mock_hw.actions == ["off:all", "on:cooling", "on:fan"]
+    mock_hw.actions.clear()
+    ctrl.set_mode("COOL_ON")
+    assert mock_hw.actions == []
+    ctrl.set_mode("HEAT_ON")
+    assert mock_hw.actions == ["off:all", "on:heating", "on:fan"]
+
+
+def test_invalid_mode():
+    ctrl = HVACController(sample_config(), hardware=MockHardwareInterface())
+    try:
+        ctrl.set_mode("BAD")
+    except ValueError:
+        pass
+    else:
+        assert False, "Expected ValueError"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,63 @@
+from datetime import datetime, timezone, timedelta
+
+from override_handler import OverrideManager
+from state_manager import StateManager
+from control import HVACController
+from tests.mocks.mock_hardware import MockHardwareInterface
+from tests.mocks.mock_sensors import MockSensorReader
+
+
+def create_state(tmpdir):
+    config = {
+        "pins": {"cooling": 17, "heating": 27, "fan": 22},
+        "thresholds": {"cool": 75, "heat": 68},
+        "motion_timeout": 300,
+        "api_key": "k",
+    }
+    sm = StateManager()
+    sm.config = config
+    return sm
+
+
+def run_cycle(state, sensors, hvac, override_mgr, now):
+    last_motion = state.get("last_motion_ts") or 0
+    temp = sensors.temperature
+    if temp is not None:
+        state.set("last_temp_f", temp)
+    if sensors.motion:
+        last_motion = now.timestamp()
+    state.set("last_motion_ts", last_motion)
+    override_mgr.clear_if_expired(now)
+    if override_mgr.is_override_active(now):
+        mode = state.get("override_mode")
+    else:
+        if temp is None:
+            mode = "OFF"
+        elif temp > state.config["thresholds"]["cool"] and now.timestamp() - last_motion < state.config["motion_timeout"]:
+            mode = "COOL_ON"
+        elif temp < state.config["thresholds"]["heat"]:
+            mode = "HEAT_ON"
+        else:
+            mode = "FAN_ONLY"
+    hvac.set_mode(mode)
+    state.set("current_mode", mode)
+
+
+def test_mode_transitions(tmp_path):
+    sm = create_state(tmp_path)
+    hvac = HVACController(sm.config, hardware=MockHardwareInterface())
+    override_mgr = OverrideManager(sm)
+
+    sensors = MockSensorReader(temperature=80.0, motion=True)
+    now = datetime.now(timezone.utc)
+    run_cycle(sm, sensors, hvac, override_mgr, now)
+    assert sm.get("current_mode") == "COOL_ON"
+
+    override_mgr.apply_override("HEAT_ON", 1, "test", "test")
+    run_cycle(sm, sensors, hvac, override_mgr, now)
+    assert sm.get("current_mode") == "HEAT_ON"
+
+    future = now + timedelta(minutes=2)
+    run_cycle(sm, sensors, hvac, override_mgr, future)
+    assert sm.get("current_mode") == "COOL_ON"
+

--- a/tests/test_override_handler.py
+++ b/tests/test_override_handler.py
@@ -1,0 +1,47 @@
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import json
+
+from override_handler import OverrideManager
+from state_manager import StateManager
+
+
+def create_state(tmpdir):
+    config_path = Path(tmpdir) / "config.json"
+    state_path = Path(tmpdir) / "state.json"
+    with open(config_path, "w") as f:
+        json.dump({"pins": {}, "thresholds": {}, "api_key": "k"}, f)
+    with open(state_path, "w") as f:
+        json.dump(StateManager.DEFAULT_STATE, f)
+    sm = StateManager(str(config_path), str(state_path))
+    return sm
+
+
+def test_apply_and_active(tmp_path):
+    sm = create_state(tmp_path)
+    om = OverrideManager(sm)
+    om.apply_override("HEAT_ON", 10, "test", "tester")
+    assert sm.get("override_mode") == "HEAT_ON"
+    assert om.is_override_active(datetime.now(timezone.utc))
+
+
+def test_invalid_mode(tmp_path):
+    sm = create_state(tmp_path)
+    om = OverrideManager(sm)
+    try:
+        om.apply_override("BAD", 5, "test", "tester")
+    except ValueError:
+        pass
+    else:
+        assert False, "Expected ValueError"
+
+
+def test_clear_if_expired(tmp_path):
+    sm = create_state(tmp_path)
+    om = OverrideManager(sm)
+    expiry = datetime.now(timezone.utc) - timedelta(minutes=1)
+    sm.set("override_mode", "COOL_ON")
+    sm.set("override_until", expiry.isoformat())
+    om.clear_if_expired(datetime.now(timezone.utc))
+    assert sm.get("override_mode") == "OFF"
+

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+import sensors
+
+
+class DummyDHT:
+    def __init__(self, pin):
+        self.temperature = 20.0
+    def exit(self):
+        pass
+
+
+class DummyGPIO:
+    BCM = 1
+    IN = 0
+    HIGH = 1
+    LOW = 0
+    def __init__(self):
+        self.state = {}
+    def setmode(self, mode):
+        pass
+    def setup(self, pin, mode):
+        pass
+    def input(self, pin):
+        return self.state.get(pin, self.LOW)
+    def cleanup(self, pins):
+        pass
+
+
+def test_sensor_reads():
+    sensors.adafruit_dht = SimpleNamespace(DHT22=DummyDHT)
+    sensors.board = SimpleNamespace(D17="D17")
+    gpio = DummyGPIO()
+    gpio.state[5] = gpio.HIGH
+    sensors.GPIO = gpio
+    mgr = sensors.SensorManager({"pins": {"dht": 17, "motion": 5}})
+    assert round(mgr.read_temperature(), 1) == 68.0
+    assert mgr.check_motion() is True

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+
+from server import SentientZoneServer
+from state_manager import StateManager
+from override_handler import OverrideManager
+from metrics import get_metrics, MetricsManager
+
+
+def create_env(tmpdir):
+    config = {
+        "pins": {},
+        "thresholds": {},
+        "api_key": "key",
+    }
+    config_path = Path(tmpdir) / "config.json"
+    state_path = Path(tmpdir) / "state.json"
+    with open(config_path, "w") as f:
+        json.dump(config, f)
+    with open(state_path, "w") as f:
+        json.dump(StateManager.DEFAULT_STATE, f)
+    sm = StateManager(str(config_path), str(state_path))
+    om = OverrideManager(sm)
+    MetricsManager.reset_instance()
+    metrics = get_metrics(Path(tmpdir) / "metrics.json")
+    metrics.record_temp(72.0)
+    server = SentientZoneServer(sm, str(Path(tmpdir)/'log.log'), om)
+    return sm, om, server, metrics
+
+
+def test_endpoints(tmp_path):
+    sm, om, srv, _ = create_env(tmp_path)
+    client = srv.app.test_client()
+    res = client.get('/state')
+    assert res.status_code == 200
+    assert res.get_json()["current_mode"] == "OFF"
+
+    res = client.get('/healthz')
+    assert res.status_code == 200
+
+    headers = {"X-API-Key": "key"}
+    payload = {"mode": "FAN_ONLY", "duration_minutes": 5}
+    res = client.post('/override', json=payload, headers=headers)
+    assert res.status_code == 200
+    assert sm.get("override_mode") == "FAN_ONLY"
+
+    res = client.post('/override', json=payload, headers={"X-API-Key": "bad"})
+    assert res.status_code == 401

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,0 +1,54 @@
+import json
+from pathlib import Path
+
+from state_manager import StateManager
+
+
+def create_paths(tmpdir):
+    config = {
+        "pins": {"dht": 4, "motion": 5, "cooling": 17, "heating": 27, "fan": 22, "button": 6},
+        "thresholds": {"cool": 75, "heat": 68},
+        "loop_interval": 5,
+        "motion_timeout": 300,
+        "api_key": "key",
+    }
+    config_path = Path(tmpdir) / "config.json"
+    state_path = Path(tmpdir) / "state.json"
+    with open(config_path, "w") as f:
+        json.dump(config, f)
+    with open(state_path, "w") as f:
+        json.dump(StateManager.DEFAULT_STATE, f)
+    return config_path, state_path
+
+
+def test_load_valid_state(tmp_path):
+    config_path, state_path = create_paths(tmp_path)
+    sm = StateManager(str(config_path), str(state_path))
+    assert sm.state == StateManager.DEFAULT_STATE
+
+
+def test_corrupted_state_file(tmp_path):
+    config_path, state_path = create_paths(tmp_path)
+    state_path.write_text("{bad json}")
+    sm = StateManager(str(config_path), str(state_path))
+    assert sm.state == StateManager.DEFAULT_STATE
+
+
+def test_schema_mismatch_resets(tmp_path):
+    config_path, state_path = create_paths(tmp_path)
+    with open(state_path, "w") as f:
+        json.dump({"bad": 1}, f)
+    sm = StateManager(str(config_path), str(state_path))
+    assert sm.state == StateManager.DEFAULT_STATE
+
+
+def test_atomic_save_and_backup(tmp_path):
+    config_path, state_path = create_paths(tmp_path)
+    sm = StateManager(str(config_path), str(state_path))
+    sm.set("current_mode", "COOL_ON")
+    backup = Path(tmp_path) / "state_backup.json"
+    assert state_path.exists()
+    assert backup.exists()
+    with open(state_path) as f:
+        data = json.load(f)
+    assert data["current_mode"] == "COOL_ON"


### PR DESCRIPTION
## Summary
- update `metrics.py` typing to use `Optional` so it runs on Python 3.9

## Testing
- `python3 -m py_compile sensors.py control.py state_manager.py server.py button_override.py main.py override_handler.py hardware.py logger.py metrics.py audit.py log_verifier.py audit_verifier.py test_mode.py`
- `pytest -q` *(fails: ModuleNotFoundError for flask/dateutil)*

------
https://chatgpt.com/codex/tasks/task_e_6845c15d7514832da9ab1bcfaa250f67