### PR TITLE
Allow configurable install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ cd SentientZone
 sudo systemctl start sz_ui.service
 ```
 
+The installer assumes the project will be placed in `/home/pi/sz` and will run
+under the `pi` user.  To override these defaults set the environment variables
+`SZ_BASE_DIR` and `SZ_USER` before running `setup.sh`:
+
+```bash
+export SZ_BASE_DIR=/opt/sz
+export SZ_USER=ubuntu
+./setup.sh
+```
+These variables are also read by `sz_ui.service`, `logger.py` and
+`metrics.py`, so the service will start correctly even if the repository lives
+outside `/home/pi`.
+
 During development you can run the program manually:
 
 ```bash

--- a/logger.py
+++ b/logger.py
@@ -1,9 +1,11 @@
 import logging
 import hashlib
+import os
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 
-LOG_PATH = Path('/home/pi/sz/logs/sentientzone.log')
+BASE_DIR = Path(os.environ.get('SZ_BASE_DIR', '/home/pi/sz'))
+LOG_PATH = BASE_DIR / 'logs' / 'sentientzone.log'
 CHAIN_PATH = LOG_PATH.parent / 'log_chain.txt'
 _FORMAT = logging.Formatter('[%(asctime)s] %(levelname)s %(name)s - %(message)s')
 _configured = False

--- a/metrics.py
+++ b/metrics.py
@@ -13,7 +13,8 @@ from typing import Optional
 
 
 
-METRICS_FILE = Path("/home/pi/sz/logs/metrics.json")
+BASE_DIR = Path(os.environ.get("SZ_BASE_DIR", "/home/pi/sz"))
+METRICS_FILE = BASE_DIR / "logs" / "metrics.json"
 
 
 class MetricsManager:

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 LOGFILE="install.log"
 exec > >(tee -a "$LOGFILE") 2>&1
 
-BASE_DIR="/home/lukep/sz"
+BASE_DIR="${SZ_BASE_DIR:-/home/pi/sz}"
+SZ_USER="${SZ_USER:-pi}"
 VENV_DIR="$BASE_DIR/venv"
 REQUIREMENTS="$BASE_DIR/requirements.txt"
 SERVICE_FILE="$BASE_DIR/sz_ui.service"

--- a/sz_ui.service
+++ b/sz_ui.service
@@ -4,10 +4,12 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/home/pi/sz/venv/bin/python /home/pi/sz/main.py
-WorkingDirectory=/home/pi/sz
+Environment=SZ_BASE_DIR=/home/pi/sz
+Environment=SZ_USER=pi
+ExecStart=${SZ_BASE_DIR}/venv/bin/python ${SZ_BASE_DIR}/main.py
+WorkingDirectory=${SZ_BASE_DIR}
 Restart=on-failure
-User=pi
+User=${SZ_USER}
 Environment=PYTHONUNBUFFERED=1
 
 [Install]


### PR DESCRIPTION
## Summary
- parameterize base directory in `logger.py` and `metrics.py`
- allow overriding base path and username in `setup.sh` and `sz_ui.service`
- document environment variables for custom install locations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e3552bf8832d8957c3e473f32d59