### PR TITLE
Improve deployment script security

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ During development you can run the program manually:
 python main.py
 ```
 
+## Deploy to Raspberry Pi
+
+Use the `deploy_to_pi.sh` script to install or update SentientZone on your Pi:
+
+```bash
+./deploy_to_pi.sh -H <pi_host> -U <pi_user> -R <repo_url> [-p]
+```
+
+Provide `-p` to be prompted for the SSH password, otherwise the script assumes
+key-based authentication.
+
 ## Directory Structure
 
 ```


### PR DESCRIPTION
## Summary
- avoid storing Raspberry Pi credentials in `deploy_to_pi.sh`
- allow host, user and repo URL to be set from the command line
- document the new deployment flow in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e356cb64832db06c0740e029fee5