### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 SentientZone
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -62,4 +62,5 @@ See the `docs/` directory for API details, configuration reference and troublesh
 
 ## Maintainer & License
 
-Maintained by the SentientZone team. Released under the MIT License.
+Maintained by the SentientZone team. Released under the MIT License. See
+[LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- include standard MIT LICENSE file
- link to LICENSE from the README

## Testing
- `flake8 --max-line-length=100 --exclude=__pycache__,logs,venv .` *(fails: various style errors)*
- `mypy --ignore-missing-imports .` *(fails: numerous typing errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845e358ad60832db643ffee139e0b85