### PR TITLE
Enhance deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ During development you can run the program manually:
 python main.py
 ```
 
+## Deploy to Raspberry Pi
+
+The `deploy_to_pi.sh` script installs or updates SentientZone on a Raspberry Pi
+configured for key-based SSH access:
+
+```bash
+./deploy_to_pi.sh -H <pi_host> -U <pi_user> -R <repo_url>
+```
+
+The repository is cloned to `/opt/sentientzone` and the service started using
+`sz_ui.service`. The script fails if an SSH connection cannot be established.
+
 
 ## Directory Structure
 


### PR DESCRIPTION
## Summary
- switch deployment to key-only SSH authentication
- add Pi connection options and error checking
- document deploy script usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e6fa5a30832d88ae4a8fb31141b1