### PR TITLE
Document secure API key handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore secrets
+config/api_key.secret
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cd SentientZone
 
 # Provide your API key securely
 export SZ_API_KEY=<your-key>
-# or place it in config/api_key.secret
+# or place it in config/api_key.secret (do not commit this file)
 
 # Start application (systemd unit installs as sz_ui.service)
 sudo systemctl start sz_ui.service

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,4 +46,5 @@ placeholder such as `CHANGE_ME`. The real key is loaded at runtime from the
 - Modify the file only when the service is stopped to avoid race conditions.
 - Keep a backup of the original configuration.
 - Store your real API key in the `SZ_API_KEY` environment variable or a file
-  specified by `SZ_API_KEY_FILE` (defaults to `config/api_key.secret`).
+  specified by `SZ_API_KEY_FILE` (defaults to `config/api_key.secret`). Never
+  commit the secrets file to version control.

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -59,3 +59,12 @@ def test_env_api_key_override(tmp_path, monkeypatch):
     monkeypatch.setenv("SZ_API_KEY", "envkey")
     sm = StateManager(str(config_path), str(state_path))
     assert sm.config["api_key"] == "envkey"
+
+
+def test_file_api_key(tmp_path, monkeypatch):
+    config_path, state_path = create_paths(tmp_path)
+    secret = tmp_path / "keyfile"
+    secret.write_text("filekey")
+    monkeypatch.setenv("SZ_API_KEY_FILE", str(secret))
+    sm = StateManager(str(config_path), str(state_path))
+    assert sm.config["api_key"] == "filekey"


### PR DESCRIPTION
## Summary
- add .gitignore for secrets and caches
- document not committing `api_key.secret`
- mention credential storage in configuration docs
- test loading API key from a secrets file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e6f70210832d862a1f8e1b6aa3b7