### PR TITLE
Allow custom base directory via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The system is organised into modules:
 - **metrics.py** – writes runtime metrics to `logs/metrics.json`
 - **main.py** – entry point coordinating the control loop and background threads
 
-Daily logs are written to `/home/pi/sz/logs/sentientzone.log` with rotation.
+Daily logs are written to `$SZ_BASE_DIR/logs/sentientzone.log` by default.
 
 ## Quickstart
 
@@ -58,6 +58,13 @@ export SZ_USER=ubuntu
 These variables are also read by `sz_ui.service`, `logger.py` and
 `metrics.py`, so the service will start correctly even if the repository lives
 outside `/home/pi`.
+
+## Environment Variables
+
+| Variable      | Description                                     | Default          |
+|---------------|-------------------------------------------------|------------------|
+| `SZ_BASE_DIR` | Base directory for the repository and runtime.  | `/home/pi/sz`    |
+| `SZ_USER`     | Linux user the systemd service runs under.      | `pi`             |
 
 During development you can run the program manually:
 

--- a/logger.py
+++ b/logger.py
@@ -4,9 +4,14 @@ import os
 from logging.handlers import TimedRotatingFileHandler
 from pathlib import Path
 
-BASE_DIR = Path(os.environ.get('SZ_BASE_DIR', '/home/pi/sz'))
-LOG_PATH = BASE_DIR / 'logs' / 'sentientzone.log'
-CHAIN_PATH = LOG_PATH.parent / 'log_chain.txt'
+def _paths() -> tuple[Path, Path, Path]:
+    """Return base, log and chain paths based on environment."""
+    base = Path(os.environ.get("SZ_BASE_DIR", "/home/pi/sz"))
+    log = base / "logs" / "sentientzone.log"
+    chain = log.parent / "log_chain.txt"
+    return base, log, chain
+
+BASE_DIR, LOG_PATH, CHAIN_PATH = _paths()
 _FORMAT = logging.Formatter('[%(asctime)s] %(levelname)s %(name)s - %(message)s')
 _configured = False
 
@@ -44,9 +49,10 @@ class HashChainingHandler(TimedRotatingFileHandler):
 
 
 def _configure() -> None:
-    global _configured
+    global _configured, BASE_DIR, LOG_PATH, CHAIN_PATH
     if _configured:
         return
+    BASE_DIR, LOG_PATH, CHAIN_PATH = _paths()
     LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
     handler = HashChainingHandler(str(LOG_PATH), CHAIN_PATH, when='midnight', backupCount=7)
     handler.setFormatter(_FORMAT)

--- a/main.py
+++ b/main.py
@@ -17,7 +17,8 @@ from logger import get_logger
 
 
 
-LOG_PATH = '/home/pi/sz/logs/sentientzone.log'
+BASE_DIR = Path(os.environ.get("SZ_BASE_DIR", "/home/pi/sz"))
+LOG_PATH = str(BASE_DIR / "logs" / "sentientzone.log")
 
 
 def main():

--- a/metrics.py
+++ b/metrics.py
@@ -11,10 +11,15 @@ from logger import get_logger
 from typing import Optional
 
 
+def _default_metrics_path() -> Path:
+    """Return metrics file path based on SZ_BASE_DIR."""
+    base = Path(os.environ.get("SZ_BASE_DIR", "/home/pi/sz"))
+    return base / "logs" / "metrics.json"
 
 
-BASE_DIR = Path(os.environ.get("SZ_BASE_DIR", "/home/pi/sz"))
-METRICS_FILE = BASE_DIR / "logs" / "metrics.json"
+
+
+
 
 
 class MetricsManager:
@@ -25,7 +30,7 @@ class MetricsManager:
     def __new__(cls, path: Optional[Path] = None) -> "MetricsManager":
         if cls._instance is None:
             cls._instance = super().__new__(cls)
-            cls._instance._init(path or METRICS_FILE)
+            cls._instance._init(path or _default_metrics_path())
         return cls._instance
 
     def _init(self, path: Path) -> None:

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,7 @@ SZ_USER="${SZ_USER:-pi}"
 VENV_DIR="$BASE_DIR/venv"
 REQUIREMENTS="$BASE_DIR/requirements.txt"
 SERVICE_FILE="$BASE_DIR/sz_ui.service"
+ENV_FILE="/etc/default/sz_ui"
 STATE_DIR="$BASE_DIR/state"
 LOG_DIR="$BASE_DIR/logs"
 
@@ -38,6 +39,10 @@ fi
 if [ -f "$REQUIREMENTS" ]; then
     "$VENV_DIR/bin/pip" install -r "$REQUIREMENTS"
 fi
+
+# Write environment file for systemd
+echo "SZ_BASE_DIR=$BASE_DIR" | sudo tee "$ENV_FILE" > /dev/null
+echo "SZ_USER=$SZ_USER" | sudo tee -a "$ENV_FILE" > /dev/null
 
 # Install systemd service
 sudo cp "$SERVICE_FILE" /etc/systemd/system/sz_ui.service

--- a/sz_ui.service
+++ b/sz_ui.service
@@ -4,8 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-Environment=SZ_BASE_DIR=/home/pi/sz
-Environment=SZ_USER=pi
+EnvironmentFile=-/etc/default/sz_ui
 ExecStart=${SZ_BASE_DIR}/venv/bin/python ${SZ_BASE_DIR}/main.py
 WorkingDirectory=${SZ_BASE_DIR}
 Restart=on-failure


### PR DESCRIPTION
## Summary
- load `SZ_BASE_DIR` in logger, metrics and main
- create systemd environment file in `setup.sh`
- read env vars from this file in `sz_ui.service`
- document environment variables in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e6f64e94832d923d09e72e4735dd