### PR TITLE
Improve installation docs and deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,8 @@ Daily logs are written to `$SZ_BASE_DIR/logs/sentientzone.log` by default.
 ## Quickstart
 
 ```bash
-# Clone repository
-git clone <REPO_URL>
-cd SentientZone
-
-# Install system and Python dependencies
-./setup.sh
+# Clone repository and run installer
+git clone <REPO_URL> && cd SentientZone && ./setup.sh
 
 # Provide your API key securely
 export SZ_API_KEY=<your-key>
@@ -45,6 +41,8 @@ export SZ_API_KEY=<your-key>
 # Start application (systemd unit installs as sz_ui.service)
 sudo systemctl start sz_ui.service
 ```
+
+This single command installs SentientZone so setup feels as effortless as installing a Nest thermostat.
 
 The installer assumes the project will be placed in `/home/pi/sz` and will run
 under the `pi` user.  To override these defaults set the environment variables
@@ -74,7 +72,6 @@ python main.py
 
 ## Deploy to Raspberry Pi
 
- f8j5tt-codex/remove-plain-text-credentials-and-improve-config
 Use the `deploy_to_pi.sh` script to install or update SentientZone on your Pi:
 
 ```bash
@@ -93,8 +90,6 @@ configured for key-based SSH access:
 
 The repository is cloned to `/opt/sentientzone` and the service started using
 `sz_ui.service`. The script fails if an SSH connection cannot be established.
-
- main
 
 ## Directory Structure
 

--- a/deploy_to_pi.sh
+++ b/deploy_to_pi.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-# Automated deployment script for SentientZone using SSH keys
+# Automated deployment script for SentientZone
 
- f8j5tt-codex/remove-plain-text-credentials-and-improve-config
 set -e
 
 usage() {
@@ -10,36 +9,19 @@ usage() {
     echo "  -U  SSH username" >&2
     echo "  -R  Git repository URL" >&2
     echo "  -p  Prompt for password instead of using SSH keys" >&2
-
-set -euo pipefail
-
-usage() {
-    echo "Usage: $0 -H <host> -U <user> -R <repo_url>" >&2
-    echo "  -H  Raspberry Pi hostname or IP" >&2
-    echo "  -U  SSH username" >&2
-    echo "  -R  Git repository URL" >&2
- main
 }
 
 PI_HOST=""
 PI_USER=""
 REPO_URL=""
- f8j5tt-codex/remove-plain-text-credentials-and-improve-config
 USE_PASS=false
 
 while getopts "H:U:R:p" opt; do
-
-
-while getopts "H:U:R:" opt; do
- main
   case "$opt" in
     H) PI_HOST="$OPTARG" ;;
     U) PI_USER="$OPTARG" ;;
     R) REPO_URL="$OPTARG" ;;
- f8j5tt-codex/remove-plain-text-credentials-and-improve-config
     p) USE_PASS=true ;;
-
- main
     *) usage; exit 1 ;;
   esac
 done
@@ -49,7 +31,6 @@ if [ -z "$PI_HOST" ] || [ -z "$PI_USER" ] || [ -z "$REPO_URL" ]; then
     exit 1
 fi
 
- f8j5tt-codex/remove-plain-text-credentials-and-improve-config
 SSH_CMD="ssh -o StrictHostKeyChecking=no"
 if $USE_PASS; then
     if ! command -v sshpass >/dev/null; then
@@ -59,22 +40,6 @@ if $USE_PASS; then
     read -s -p "Password for $PI_USER@$PI_HOST: " PI_PASS
     echo
     SSH_CMD="sshpass -p \"$PI_PASS\" ssh -o StrictHostKeyChecking=no"
-
-if ! command -v ssh >/dev/null; then
-    echo "ssh command not found" >&2
-    exit 1
-fi
-
-if ! command -v git >/dev/null; then
-    echo "git command not found" >&2
-    exit 1
-fi
-
-SSH_CMD="ssh -o BatchMode=yes -o StrictHostKeyChecking=no"
-if ! $SSH_CMD "$PI_USER@$PI_HOST" exit >/dev/null 2>&1; then
-    echo "SSH connection failed. Ensure key-based authentication is configured." >&2
-    exit 1
- main
 fi
 
 $SSH_CMD $PI_USER@$PI_HOST <<EOF_REMOTE


### PR DESCRIPTION
## Summary
- streamline Quickstart instructions with a single command
- clean up README sections and remove stray tokens
- restore functional deploy_to_pi.sh script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846581867f4832dbe418141abe9f84e